### PR TITLE
docs: enhance fix-review-comments skill with auto-commit and rule updates

### DIFF
--- a/.claude/rules/repository.md
+++ b/.claude/rules/repository.md
@@ -476,6 +476,32 @@ func ExampleToDBModel(m *model.Example) *dbmodel.Example {
 
 **Note**: `ReadonlyReference` is never converted back to DB model - it's read-only.
 
+### Struct Literal Return Rule
+
+**All conversion functions must use struct literal initialization in the return statement.** Do not create an empty struct and assign fields one by one.
+
+```go
+// GOOD - struct literal with all fields
+func TenantToModel(s *dbmodel.Tenant) *model.Tenant {
+    return &model.Tenant{
+        ID:                s.ID,
+        Name:              s.Name,
+        ReadonlyReference: nil,
+    }
+}
+
+// BAD - field-by-field assignment
+func TenantToModel(s *dbmodel.Tenant) *model.Tenant {
+    m := &model.Tenant{}
+    m.ID = s.ID
+    m.Name = s.Name
+    m.ReadonlyReference = nil
+    return m
+}
+```
+
+**Exception**: When conditional assignment is needed (e.g., `ReadonlyReference`, nullable timestamps), use `m := &XXX{...}` with all non-conditional fields in the literal, then conditional blocks, then `return m`.
+
 ## Transaction Context
 
 Always use `transactable.GetContextExecutor(ctx)` to get the database executor:

--- a/.claude/rules/usecase-interactor.md
+++ b/.claude/rules/usecase-interactor.md
@@ -814,25 +814,33 @@ if param.Role.Valid {
 
 ## Domain Method Usage (Domain Logic First)
 
-**IMPORTANT**: Always use domain model methods for state changes instead of direct field assignment.
+**IMPORTANT**: All domain model operations (creation and state changes) MUST use domain model constructors and methods. Never directly initialize structs or assign fields in the usecase layer.
 
-### Good Pattern
+### Creation: Use Constructors
 
 ```go
-// In usecase
-if param.Role.Valid {
-    admin.UpdateRole(param.Role.Value(), param.RequestTime)
+// GOOD - use domain constructor
+staff := model.NewStaff(param.TenantID, param.Role, param.AuthUID, param.DisplayName, param.ImagePath, param.Email, param.RequestTime)
+
+// BAD - direct struct initialization in usecase
+staff := &model.Staff{
+    ID:          id.New(),
+    TenantID:    param.TenantID,
+    Role:        param.Role,
+    CreatedAt:   param.RequestTime,
+    UpdatedAt:   param.RequestTime,
 }
 ```
 
-### Anti-Pattern
+### Updates: Use Domain Methods
 
 ```go
-// Don't do this in usecase
-if param.Role.Valid {
-    admin.Role = param.Role.Value()
-    admin.UpdatedAt = param.RequestTime
-}
+// GOOD
+admin.UpdateRole(param.Role.Value(), param.RequestTime)
+
+// BAD - direct field assignment
+admin.Role = param.Role.Value()
+admin.UpdatedAt = param.RequestTime
 ```
 
 See `domain-model.md` for more details on domain method patterns.

--- a/.claude/skills/fix-review-comments/SKILL.md
+++ b/.claude/skills/fix-review-comments/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: fix-review-comments
-description: Fetch unresolved GitHub PR review comments and automatically fix the code. Use when: (1) running '/fix-review-comments', (2) asked to "fix review comments", "address PR comments", "respond to review", or similar. Can target the PR for the current branch, or a specific PR number (e.g. '/fix-review-comments 123'). Skips already-resolved threads and discussion-only comments that require no code change.
+description: Fetch unresolved GitHub PR review comments and automatically fix the code, commit, and push. Use when: (1) running '/fix-review-comments', (2) asked to "fix review comments", "address PR comments", "respond to review", or similar. Can target the PR for the current branch, or a specific PR number (e.g. '/fix-review-comments 123'). Skips already-resolved threads and discussion-only comments that require no code change. Also updates Claude rules and review-diff anti-patterns when a comment reveals a missing convention.
 ---
 
 # Fix Review Comments
 
-Fetch unresolved PR review threads and fix the code automatically.
+Fetch unresolved PR review threads, fix code, update rules if needed, then commit and push.
 
 ## Step 1: Detect PR
 
 ```bash
 # From current branch (no argument)
-gh pr view --json number,url | jq -r '"#\(.number) \(.url)"'
+gh pr view --json number,url,headRefName | jq -r '"#\(.number) \(.url) \(.headRefName)"'
 
 # Or use the number passed as argument
 ```
@@ -78,7 +78,39 @@ For each thread requiring a fix:
 
 Fix all actionable threads before running any verification.
 
-## Step 5: Verify
+## Step 5: Update Rules (if applicable)
+
+After fixing code, evaluate whether any comment reveals a **missing or incomplete coding convention** that should be captured in project rules. Ask:
+
+- Could this mistake recur if the rule isn't documented?
+- Is it a pattern-level issue (not just a one-off typo)?
+
+If yes, update the appropriate file(s):
+
+| Comment type | Target file |
+|---|---|
+| AI-generated code pattern mistake | `.claude/skills/review-diff/references/ai-antipatterns.md` — add new numbered pattern, renumber subsequent |
+| Domain model / entity convention | `.claude/rules/domain-model.md` |
+| Repository / marshaller pattern | `.claude/rules/repository.md` |
+| Usecase / interactor convention | `.claude/rules/usecase-interactor.md` |
+| gRPC handler pattern | `.claude/rules/grpc-handler.md` |
+| Testing convention | `.claude/rules/testing.md` |
+| Proto definition style | `.claude/rules/proto-definition.md` |
+| Other layer-specific rule | Corresponding `.claude/rules/*.md` |
+
+When adding to `ai-antipatterns.md`:
+1. Assign the next sequential number
+2. Include BAD/GOOD code examples from the actual review comment
+3. Renumber all subsequent patterns
+4. Update `.claude/skills/review-diff/SKILL.md` priority list if the pattern is critical
+
+When adding to `.claude/rules/*.md`:
+1. Add the rule in the appropriate section
+2. Follow the existing format (tables, code blocks, etc.)
+
+**Do NOT update rules for**: one-off typos, project-specific business logic, or comments that are already covered by existing rules.
+
+## Step 6: Verify
 
 ```bash
 /usr/bin/make lint.go
@@ -89,7 +121,24 @@ Run tests if logic changed:
 /usr/bin/make test
 ```
 
-## Step 6: Report
+## Step 7: Commit and Push
+
+Stage, commit, and push all changes (code fixes + rule updates):
+
+```bash
+git add -A
+git commit -m "fix: address PR review comments
+
+- <summary of code fixes>
+- <summary of rule updates, if any>"
+git push
+```
+
+If code fixes and rule updates are logically separate, use two commits:
+1. Code fixes first: `fix: address PR #NNN review comments`
+2. Rule updates second: `docs: update rules from PR #NNN review feedback`
+
+## Step 8: Report
 
 ```
 ## Fix Review Comments Summary
@@ -100,6 +149,11 @@ PR: #NNN
 1. `path/to/file.go:line` — short description of fix
    Comment: "@author: ..."
 
+### Rules Updated (N)
+1. `.claude/rules/xxx.md` — added rule about ...
+   Triggered by: "@author: ..." comment on `path/to/file.go`
+2. `.claude/skills/review-diff/references/ai-antipatterns.md` — added #NN: ...
+
 ### Skipped (N)
 1. `path/to/file.go:line` — reason (already resolved / discussion / no code change needed)
    Comment: "@author: ..."
@@ -107,10 +161,10 @@ PR: #NNN
 ### Verification
 - [x] lint.go passes
 - [x] tests pass
+- [x] committed and pushed
 ```
 
 ## Notes
 
-- Do **not** auto-commit — leave that to the user
 - Do **not** resolve threads via the API — the user confirms fixes via GitHub UI
 - If a thread's `isOutdated == true` and the problem no longer exists in current code, note it in the Skipped section with reason "already fixed (outdated thread)"

--- a/.claude/skills/review-diff/SKILL.md
+++ b/.claude/skills/review-diff/SKILL.md
@@ -52,6 +52,9 @@ Read `references/ai-antipatterns.md`. Check **every changed file** against all p
 - **#6** Direct model initialization instead of using `factory.NewFactory()` in tests
 - **#12** Fully-owned entity placed in `ReadonlyReference` instead of direct field
 - **#25** Private method defined in usecase interactor
+- **#36** Direct domain model struct initialization in usecase (bypassing constructor)
+- **#37** Unnecessary nil/valid checks on guaranteed values
+- **#39** Field-by-field struct construction in conversion functions
 
 Record each finding: file path, line number, pattern violated, fix to apply.
 

--- a/.claude/skills/review-diff/references/ai-antipatterns.md
+++ b/.claude/skills/review-diff/references/ai-antipatterns.md
@@ -629,3 +629,149 @@ if featureEnabled {
 ```
 
 Just implement the new behavior directly.
+
+---
+
+### 36. Direct domain model struct initialization in usecase (bypassing constructor)
+
+```go
+// BAD - direct struct literal in usecase
+func (i *adminStaffInteractor) Create(...) (*model.Staff, error) {
+    staff := &model.Staff{
+        ID:          id.New(),
+        TenantID:    param.TenantID,
+        Role:        param.Role,
+        DisplayName: param.DisplayName,
+        CreatedAt:   param.RequestTime,
+        UpdatedAt:   param.RequestTime,
+    }
+    return staff, nil
+}
+
+// GOOD - use domain model constructor
+func (i *adminStaffInteractor) Create(...) (*model.Staff, error) {
+    staff := model.NewStaff(
+        param.TenantID,
+        param.Role,
+        param.AuthUID,
+        param.DisplayName,
+        param.ImagePath,
+        param.Email,
+        param.RequestTime,
+    )
+    return staff, nil
+}
+```
+
+**Why**: Constructors encapsulate initialization logic (ID generation, default values, field constraints). Bypassing them risks missing required fields and duplicates logic across call sites.
+
+**Note**: This is distinct from #7 (direct field assignment for updates). #7 is about mutation; this is about creation.
+
+---
+
+### 37. Unnecessary nil/valid checks on guaranteed values
+
+```go
+// BAD - staff is guaranteed non-nil by OrFail: true
+staff, err := i.staffRepository.Get(ctx, repository.GetStaffQuery{
+    ID:             null.StringFrom(param.StaffID),
+    BaseGetOptions: repository.BaseGetOptions{OrFail: true},
+})
+if err != nil {
+    return nil, err
+}
+if staff == nil {  // Unnecessary - OrFail guarantees non-nil on success
+    return nil, errors.StaffNotFoundErr.New()
+}
+
+// GOOD - trust OrFail guarantee
+staff, err := i.staffRepository.Get(ctx, repository.GetStaffQuery{
+    ID:             null.StringFrom(param.StaffID),
+    BaseGetOptions: repository.BaseGetOptions{OrFail: true},
+})
+if err != nil {
+    return nil, err
+}
+// Use staff directly
+
+// BAD - checking .Valid on a value just set with TypeFrom
+role := nullable.TypeFrom(param.Role)
+if role.Valid {  // Always true
+    query.Role = role
+}
+
+// GOOD
+query.Role = nullable.TypeFrom(param.Role)
+```
+
+**Fix**: Remove nil/valid checks when the preceding code guarantees the value. Trust `OrFail`, `TypeFrom`, `StringFrom`, and similar constructors.
+
+---
+
+### 38. Unnecessary intermediate variable declarations
+
+```go
+// BAD - unnecessary variable
+result := someFunction(ctx, param)
+return result
+
+// GOOD
+return someFunction(ctx, param)
+
+// BAD - declaring then immediately returning
+staffs, err := i.staffRepository.List(ctx, query)
+if err != nil {
+    return nil, err
+}
+result := &output.AdminListStaffs{
+    Staffs:     staffs,
+    TotalCount: totalCount,
+}
+return result, nil
+
+// GOOD - return directly
+staffs, err := i.staffRepository.List(ctx, query)
+if err != nil {
+    return nil, err
+}
+return &output.AdminListStaffs{
+    Staffs:     staffs,
+    TotalCount: totalCount,
+}, nil
+```
+
+**Exception**: Variables are acceptable when (1) the value is used multiple times, (2) conditional mutation is needed (e.g., nullable timestamp fields in marshallers), or (3) readability significantly improves.
+
+---
+
+### 39. Field-by-field struct construction in conversion functions
+
+```go
+// BAD - empty struct then field-by-field assignment
+func StaffToPB(m *model.Staff) *pb.Staff {
+    result := &pb.Staff{}
+    result.Id = m.ID
+    result.DisplayName = m.DisplayName
+    result.Email = m.Email
+    result.Role = StaffRoleToPB(m.Role)
+    result.CreatedAt = timestamppb.New(m.CreatedAt)
+    result.UpdatedAt = timestamppb.New(m.UpdatedAt)
+    return result
+}
+
+// GOOD - struct literal with all fields
+func StaffToPB(m *model.Staff) *pb.Staff {
+    return &pb.Staff{
+        Id:          m.ID,
+        DisplayName: m.DisplayName,
+        Email:       m.Email,
+        Role:        StaffRoleToPB(m.Role),
+        CreatedAt:   timestamppb.New(m.CreatedAt),
+        UpdatedAt:   timestamppb.New(m.UpdatedAt),
+    }
+}
+```
+
+**Why**: Field-by-field assignment makes it easy to miss fields silently. Struct literals cause compile errors when fields are added, catching omissions early.
+
+**Exception**: When conditional field assignment is needed (e.g., `ReadonlyReference` or nullable timestamps), use `m := &XXX{...}` with conditional blocks, then `return m`. But all non-conditional fields must still be in the initial struct literal.

--- a/.claude/skills/review-diff/references/checklists.md
+++ b/.claude/skills/review-diff/references/checklists.md
@@ -39,6 +39,7 @@ Detailed checklists for each file category. Apply the relevant sections based on
 - [ ] Enum conversions handle all cases including Unknown/default
 - [ ] Slice conversion function defined (`{Entity}sToModel`)
 - [ ] Related entity's `ReadonlyReference` always nil (no recursive loading)
+- [ ] Uses struct literal return (not field-by-field assignment on empty struct)
 
 ## Usecase Interactor (`internal/usecase/**`)
 
@@ -47,7 +48,10 @@ Detailed checklists for each file category. Apply the relevant sections based on
 - [ ] All methods start with `param.Validate()` check
 - [ ] Write operations wrapped in `transactable.RWTx`
 - [ ] Get before update uses `ForUpdate: true` for locking
+- [ ] Entity creation uses domain constructors (`model.NewXxx()`), not direct struct init
 - [ ] State changes use domain methods (not direct field assignment)
+- [ ] No unnecessary nil/valid checks on values guaranteed by preceding code
+- [ ] No unnecessary intermediate variable declarations (return directly when possible)
 - [ ] IdP sync (StoreClaims/DeleteUser) happens within transaction
 - [ ] On delete: IdP deletion before database deletion
 - [ ] Final return fetches entity with `Preload: true` for fresh data
@@ -78,6 +82,7 @@ Detailed checklists for each file category. Apply the relevant sections based on
 - [ ] Enum conversions have both `ToPb` and `ToModel` directions
 - [ ] Slice conversion function defined (`{Entity}sToPb`)
 - [ ] All proto fields are explicitly mapped (check for omissions)
+- [ ] Uses struct literal return (not field-by-field assignment on empty struct)
 
 ## Proto Definition (`schema/proto/**`)
 


### PR DESCRIPTION
## Summary
- Add auto-update of Claude rules (`.claude/rules/*.md`) and AI anti-patterns when a review comment reveals a missing coding convention
- Add auto-commit and push after applying fixes (previously left to user)
- Update report template with "Rules Updated" section

## Test plan
- [ ] Run `/fix-review-comments` on a PR with review comments and verify rules are updated when applicable
- [ ] Verify auto-commit and push works after fixes are applied
- [ ] Verify report includes Rules Updated section

🤖 Generated with [Claude Code](https://claude.com/claude-code)