### PR TITLE
docs: ban package-level private functions across all layers

### DIFF
--- a/.claude/skills/review-diff/SKILL.md
+++ b/.claude/skills/review-diff/SKILL.md
@@ -51,7 +51,8 @@ Read `references/ai-antipatterns.md`. Check **every changed file** against all p
 - **#1** `gomock.Any()` for non-context parameters (no exceptions)
 - **#6** Direct model initialization instead of using `factory.NewFactory()` in tests
 - **#12** Fully-owned entity placed in `ReadonlyReference` instead of direct field
-- **#25** Private method defined in usecase interactor
+- **#25** Private method defined in usecase interactor (receiver method)
+- **#31** Package-level private functions in domain/usecase/infrastructure layers
 - **#36** Direct domain model struct initialization in usecase (bypassing constructor)
 - **#37** Unnecessary nil/valid checks on guaranteed values
 - **#39** Field-by-field struct construction in conversion functions

--- a/.claude/skills/review-diff/references/ai-antipatterns.md
+++ b/.claude/skills/review-diff/references/ai-antipatterns.md
@@ -570,20 +570,48 @@ enum StaffRole {
 
 ## General AI Patterns (Across All Layers)
 
-### 31. Unnecessary helper abstractions for one-time use
+### 31. Package-level private functions
 
-AI often creates helper functions that are only called once. Remove and inline.
+Package-level private functions (non-receiver functions) are prohibited in domain, usecase, and infrastructure layers. They pollute the package namespace and scatter logic.
 
 ```go
-// BAD - one-time helper
+// BAD - package-level private function
 func buildStaffQuery(id string) repository.GetStaffQuery {
     return repository.GetStaffQuery{...}
 }
-// Only called in one place
 
-// GOOD - inline it
+// BAD - package-level private helper
+func toStaffModel(param *input.AdminCreateStaff, t time.Time) *model.Staff {
+    return model.NewStaff(param.TenantID, param.Role, ...)
+}
+
+// BAD - package-level validation helper
+func validateStaffInput(param *input.AdminCreateStaff) error {
+    if param.Email == "" {
+        return errors.RequestInvalidArgumentErr.New()
+    }
+    return nil
+}
+
+// GOOD - inline the logic
 staff, err := i.repo.Get(ctx, repository.GetStaffQuery{...})
+
+// GOOD - method on domain model
+func (m *Staff) Validate() error { ... }
+
+// GOOD - method on domain service struct
+func (s *staffService) Create(ctx context.Context, param StaffCreateParam) (*model.Staff, error) { ... }
 ```
+
+**Decision guide:**
+| Situation | Solution |
+|---|---|
+| Short logic (few lines) | Inline in the calling method |
+| Reusable business logic | Method on domain model or domain service |
+| Data conversion | Method on marshaller struct, or inline |
+| Validation | Method on input struct or domain model |
+
+**Exception**: Package-level private functions are acceptable only when they are pure utility functions with no domain knowledge (e.g., generic type conversion helpers). Even then, prefer placing them in a shared `pkg/` utility package.
 
 ---
 

--- a/.claude/skills/review-diff/references/checklists.md
+++ b/.claude/skills/review-diff/references/checklists.md
@@ -4,6 +4,7 @@ Detailed checklists for each file category. Apply the relevant sections based on
 
 ## Domain Model (`internal/domain/model/**`)
 
+- [ ] No package-level private functions (inline or move to model method)
 - [ ] Entity has `ReadonlyReference` struct pointer for relations
 - [ ] Constructor uses `id.New()` for ID generation
 - [ ] Constructor sets both `CreatedAt` and `UpdatedAt` to same time
@@ -25,6 +26,7 @@ Detailed checklists for each file category. Apply the relevant sections based on
 
 ## Repository Implementation (`internal/infrastructure/**/repository/**`)
 
+- [ ] No package-level private functions (inline or move to struct method)
 - [ ] Uses `transactable.GetContextExecutor(ctx)` for all queries
 - [ ] `Get` method handles `OrFail` correctly (nil vs error on not found)
 - [ ] `Get` method handles `ForUpdate` option
@@ -43,6 +45,7 @@ Detailed checklists for each file category. Apply the relevant sections based on
 
 ## Usecase Interactor (`internal/usecase/**`)
 
+- [ ] No package-level private functions (inline or move to struct method)
 - [ ] Interface has `//go:generate` directive
 - [ ] Implementation uses dependency injection via constructor
 - [ ] All methods start with `param.Validate()` check


### PR DESCRIPTION
## Summary
- Update ai-antipatterns #31: expand from "unnecessary helper abstractions" to prohibiting package-level private functions in domain/usecase/infrastructure layers
- Add to review-diff priority patterns
- Add checklist items for domain model, repository, and usecase layers

## Test plan
- [ ] Verify `/review-diff` detects package-level private functions in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)