### PR TITLE
chore: pin aarondl/null to v8 in renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,10 @@
 {
   "extends": ["config:base"],
-  "packageRules": []
+  "packageRules": [
+    {
+      "matchPackageNames": ["github.com/aarondl/null"],
+      "allowedVersions": "<= 8",
+      "description": "Pin to v8 to align with SQLBoiler's dependency. v9 is intentionally not used."
+    }
+  ]
 }


### PR DESCRIPTION
## Proposed Changes

- Prevent Renovate from upgrading `aarondl/null` beyond v8

## Implementation

Added a `packageRules` entry in `renovate.json` to cap `github.com/aarondl/null` at `<= 8`.
This aligns with SQLBoiler's transitive dependency on v8 and the intentional v9 → v8 downgrade in #1867.