### PR TITLE
Add sync-claude-config skill

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -120,6 +120,7 @@ Available automation skills in `.claude/skills/`:
 | `review-diff` | Review & auto-fix current branch diff against main/master. Catches AI anti-patterns and rule violations, then fixes them automatically |
 | `fix-review-comments` | Fetch unresolved GitHub PR review comments and auto-fix the code. Run `/fix-review-comments` (current branch PR) or `/fix-review-comments 123` (specific PR) |
 | `create-pull-request` | PR creation guide with branch naming and body templates |
+| `sync-claude-config` | Bidirectionally sync `.claude/` content with the rapid-go template (or a derived project added via `claude --add-dir`); opens a PR in each repo |
 
 **Implementation Workflow**: `add-database-table` → `add-domain-entity` → `add-api-endpoint`
 

--- a/.claude/skills/sync-claude-config/SKILL.md
+++ b/.claude/skills/sync-claude-config/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: sync-claude-config
+description: "Bidirectionally sync .claude/ content (skills, rules, agents, commands, CLAUDE.md) between this project and the rapid-go template. Use when: (1) running /sync-claude-config, (2) you want project-local Claude-config improvements pushed upstream to rapid-go and upstream improvements pulled down, (3) coordinating changes across multiple rapid-go-derived projects. Requires rapid-go added via `claude --add-dir <rapid-go-path>` before running."
+---
+
+# sync-claude-config
+
+Bidirectionally syncs `.claude/` content between this project and the rapid-go upstream template, creating a PR in each repo for changes that flow in each direction.
+
+## Prerequisites
+
+Both repositories must be accessible:
+- **LOCAL** — the current project (where you invoke the skill)
+- **UPSTREAM** — rapid-go
+
+Before running this skill, add rapid-go as an additional directory:
+
+```
+/add-dir /path/to/rapid-go
+```
+
+If only one repository root is visible, stop and prompt the user to run the above command. Do NOT proceed without both repos accessible — the skill cannot diff them.
+
+## Step 0 — Identify Repos & Tokens
+
+Determine which root is LOCAL and which is UPSTREAM.
+
+```bash
+# Current project root
+git rev-parse --show-toplevel
+
+# Identify rapid-go root among the accessible directories by checking
+# (any one of these conditions is sufficient):
+#   go.mod module == github.com/abyssparanoia/rapid-go
+#   schema/proto/rapid/ exists
+#   .claude/skills/init-new-repository/ exists
+```
+
+If the skill is invoked FROM rapid-go (i.e., current project IS rapid-go) and a derived project was added via `--add-dir`, swap roles: LOCAL = derived project, UPSTREAM = rapid-go. The logic is always: UPSTREAM = rapid-go, LOCAL = the other.
+
+Read the LOCAL project's token values for normalization (see `references/token-mapping.md` for full mapping):
+
+| Token | How to read |
+|-------|-------------|
+| `{go-module}` | First line of `go.mod`: `module github.com/...` |
+| `{service-name}` | Directory name under `schema/proto/` that is NOT `google` or `protoc-gen-openapiv2` |
+| `{project-title}` | H1 line in `.claude/CLAUDE.md`: `# Project Title` |
+| `{buf-org}` | `buf.yaml` or `buf.gen.yaml`: the org before `/{service-name}` in registry URL |
+| `{docker-network}` | `docker-compose.yml`: the custom network name (e.g. `myapp-network`) |
+| `{org}/{repo}` | Derive from `{go-module}` after `github.com/` |
+| `{database}` | Which of `db/mysql/` or `db/postgresql/` exists |
+
+## Step 1 — Enumerate Candidates
+
+Build the set of in-scope file paths on both sides. In-scope paths:
+
+```
+.claude/CLAUDE.md
+.claude/rules/**/*.md
+.claude/skills/**    (all files recursively)
+.claude/agents/**/*.md
+.claude/commands/**/*.md
+```
+
+**Always exclude** (never sync these):
+
+```
+.claude/settings.local.json
+.claude/worktrees/**
+.claude/skills/init-new-repository/**   ← intentionally template-bearing; stays in rapid-go only
+```
+
+Compute the **union** of relative paths from both sides.
+
+## Step 2 — Normalize & Classify
+
+For each path in the union, classify it into one of four buckets. Detailed algorithm in `references/sync-algorithm.md`. Summary:
+
+1. Read file content from both sides (use `null` when the file doesn't exist on one side).
+2. Normalize the LOCAL version by applying the **reverse token map** (local → rapid-go canonical). Full map in `references/token-mapping.md`. Apply replacements longest-first to avoid partial matches.
+3. Compare normalized-LOCAL vs UPSTREAM content:
+
+| Exists in UPSTREAM | Exists in LOCAL | Match after normalization | Classification |
+|--------------------|-----------------|--------------------------|----------------|
+| Yes | No | — | **pull** (add to LOCAL) |
+| No | Yes | — | **push** (add to UPSTREAM) |
+| Yes | Yes | Yes | **skip** (identical, no action) |
+| Yes | Yes | No | **conflict** (changed on both sides) |
+
+4. For **conflict** files:
+   - Run `git -C <UPSTREAM> log -1 --format="%ct %H %s" -- <relpath>` and `git -C <LOCAL> log -1 --format="%ct %H %s" -- <relpath>`. Compare unix timestamps.
+   - If only DB-variant lines differ (e.g. `` `mysql` `` vs `` `postgresql` `` in examples), mark **skip — DB-specific** instead.
+   - Otherwise present the normalized diff and timestamp hint. Ask which side is canonical before proceeding.
+
+## Step 3 — Present Plan & Confirm
+
+Print a consolidated table before touching anything:
+
+```
+PULL  →  LOCAL       (changes from rapid-go into this project)
+─────────────────────────────────────────────────────────────
+.claude/rules/new-rule.md                [new file]
+.claude/skills/new-skill/SKILL.md        [new file]
+.claude/rules/grpc-handler.md            [conflict → upstream newer: 2025-06-01]
+
+PUSH  →  UPSTREAM    (changes from this project into rapid-go)
+─────────────────────────────────────────────────────────────
+.claude/rules/project-specific.md        [new file]
+.claude/rules/testing.md                 [conflict → local newer: 2025-06-03]
+
+SKIP (no effective change after normalization): 14 files
+SKIP (DB-specific difference): 2 files
+```
+
+**Do not apply any changes until the user explicitly confirms.**
+
+For each conflict, show the diff (normalized) and ask: "Apply [upstream | local] version?" before including it in the plan.
+
+If there are no changes in either direction, report that and stop — do not create empty branches/PRs.
+
+## Step 4 — Apply Changes
+
+After confirmation, apply the classified changes:
+
+**Pull → LOCAL** (rapid-go content into this project):
+- Take the UPSTREAM file content.
+- Apply the **forward token map** (rapid-go canonical → local tokens) to localize it.
+- Write/overwrite the file at `<LOCAL>/<relpath>`.
+
+**Push → UPSTREAM** (local content into rapid-go):
+- Take the LOCAL file content.
+- Apply the **reverse token map** (local → rapid-go canonical) to canonicalize it.
+- Write/overwrite the file at `<UPSTREAM>/<relpath>`.
+
+Use the Write and Edit tools for LOCAL; use absolute paths under the UPSTREAM root for UPSTREAM files.
+
+## Step 5 — Create PRs (Both Directions)
+
+Follow `.claude/skills/create-pull-request/SKILL.md` conventions. **No AI attribution**.
+
+### PR in LOCAL repo (pull changes from upstream)
+
+```bash
+# From LOCAL repo root
+git checkout -b chore/sync-claude-config
+git add .claude/
+git commit -m "chore: sync .claude/ config from rapid-go"
+git push -u origin chore/sync-claude-config
+gh pr create \
+  --title "Sync .claude/ config from rapid-go" \
+  --body "$(cat <<'EOF'
+## Proposed Changes
+
+- Pulled .claude/ content updates from rapid-go upstream template
+
+## Implementation
+
+Files synced from rapid-go:
+<list pulled files>
+
+EOF
+)"
+```
+
+### PR in UPSTREAM repo (push changes from local)
+
+```bash
+# All git commands use -C <UPSTREAM> to target the upstream repo
+git -C <UPSTREAM> checkout -b chore/sync-claude-config-from-<service-name>
+git -C <UPSTREAM> add .claude/
+git -C <UPSTREAM> commit -m "chore: sync .claude/ config from <service-name>"
+git -C <UPSTREAM> push -u origin chore/sync-claude-config-from-<service-name>
+gh pr create \
+  -R abyssparanoia/rapid-go \
+  --title "Sync .claude/ config from <service-name>" \
+  --body "$(cat <<'EOF'
+## Proposed Changes
+
+- Pulled .claude/ content updates contributed by <service-name>
+
+## Implementation
+
+Files synced:
+<list pushed files>
+
+EOF
+)"
+```
+
+Only open a PR on a side that actually received file changes. If one side has nothing to receive, skip that PR.
+
+## Step 6 — Done
+
+Report the PR URLs created and remind the user:
+
+> After the rapid-go PR merges, other projects can run `/sync-claude-config` (with rapid-go added via `--add-dir`) to pull in the newly landed changes.

--- a/.claude/skills/sync-claude-config/references/sync-algorithm.md
+++ b/.claude/skills/sync-claude-config/references/sync-algorithm.md
@@ -1,0 +1,166 @@
+# Sync Algorithm Reference
+
+Detailed specification for the classification and conflict-resolution algorithm used in `sync-claude-config`.
+
+## Exclusion List
+
+Never include these in the sync candidate set regardless of which side they appear on:
+
+```
+.claude/settings.local.json
+.claude/worktrees/           (entire directory)
+.claude/skills/init-new-repository/   (entire skill directory — intentionally template-bearing)
+```
+
+## In-Scope Paths
+
+Enumerate recursively under these roots relative to the repo root:
+
+```
+.claude/CLAUDE.md                 (single file)
+.claude/rules/                    (all .md files)
+.claude/skills/                   (all files, all subdirs, EXCEPT init-new-repository/)
+.claude/agents/                   (all .md files)
+.claude/commands/                 (all .md files)
+```
+
+Include all file types (not just `.md`) under `skills/` — skills may contain Python scripts,
+JSON, YAML, etc. that should also sync.
+
+## Classification Algorithm
+
+For each path `p` in the union of both sides:
+
+```
+exists_upstream = file exists at <UPSTREAM>/.claude/<p>
+exists_local    = file exists at <LOCAL>/.claude/<p>
+
+if exists_upstream and not exists_local:
+    → PULL  (new file from upstream, localize tokens, write into LOCAL)
+
+if exists_local and not exists_upstream:
+    → PUSH  (new file from local, canonicalize tokens, write into UPSTREAM)
+
+if exists_upstream and exists_local:
+    canonical_upstream = read(<UPSTREAM>/.claude/<p>)
+    canonical_local    = apply_reverse_map(read(<LOCAL>/.claude/<p>))
+
+    if canonical_upstream == canonical_local:
+        → SKIP (identical)
+    else:
+        diff = compute_diff(canonical_upstream, canonical_local)
+
+        if is_db_variant_only(diff):
+            → SKIP — DB-specific
+
+        → CONFLICT: resolve per rules below
+```
+
+## DB-Variant Detection
+
+A diff is "DB-variant only" if every changed line (additions and removals) satisfies at
+least one of:
+
+- The line contains the literal string `mysql` or `postgresql` (case-insensitive)
+- The line is a quoting-style difference introduced by MySQL (backtick) vs PostgreSQL
+  (double-quote) identifier quoting in SQL/Go ORDER BY strings
+
+If ANY changed line does NOT satisfy this condition, the diff is NOT DB-variant only.
+
+## Conflict Resolution
+
+When a file exists on both sides and differs after normalization:
+
+1. Run timestamp check:
+   ```bash
+   git -C <UPSTREAM> log -1 --format="%ct %h %s" -- .claude/<relpath>
+   git -C <LOCAL>    log -1 --format="%ct %h %s" -- .claude/<relpath>
+   ```
+   Note: timestamp is unix epoch (seconds). Newer = more recently committed = likely the
+   authoritative version. If a file has never been committed on one side (`git log` returns
+   empty), treat that side as older.
+
+2. Present to the user:
+   ```
+   CONFLICT: .claude/rules/example-rule.md
+   ─────────────────────────────────────────
+   upstream last commit: 2025-05-28 (abc1234) "update grpc handler rule"
+   local    last commit: 2025-06-03 (def5678) "add new validation pattern"
+
+   Normalized diff (upstream ← → local):
+   --- upstream
+   +++ local
+   @@ -12,4 +12,8 @@
+    existing line
+   +new validation pattern added in local
+   ...
+
+   Which version should be canonical?
+   [U] upstream  [L] local  [S] skip this file
+   ```
+
+3. Based on user choice:
+   - **U (upstream)**: Add file to PULL plan (overwrite local with localized upstream version)
+   - **L (local)**: Add file to PUSH plan (overwrite upstream with canonicalized local version)
+   - **S (skip)**: Do not include in either PR
+
+## Token Replacement Implementation
+
+When applying the reverse map (LOCAL → canonical) or forward map (canonical → LOCAL):
+
+1. Substitute literal strings in the file content (not regex — plain string replacement)
+2. Apply in the order specified in `token-mapping.md` (longest/most-specific first)
+3. Both forward and reverse maps are applied to the **entire file content** as a string
+4. Binary files are skipped (apply only to UTF-8 text files)
+
+To detect if a file is binary: if it contains a null byte (`\x00`), treat as binary and skip.
+
+## Summary Table Format
+
+Present this table before any changes are applied:
+
+```
+══════════════════════════════════════════════════════════
+PULL → LOCAL  (these files will be added/updated locally)
+══════════════════════════════════════════════════════════
+  [NEW]      .claude/skills/new-skill/SKILL.md
+  [NEW]      .claude/rules/new-convention.md
+  [CONFLICT] .claude/rules/grpc-handler.md        (upstream newer: 2025-06-01)
+
+══════════════════════════════════════════════════════════
+PUSH → UPSTREAM  (these files will be added/updated in rapid-go)
+══════════════════════════════════════════════════════════
+  [NEW]      .claude/rules/local-only-rule.md
+  [CONFLICT] .claude/rules/testing.md             (local newer: 2025-06-03)
+
+══════════════════════════════════════════════════════════
+SKIPPED
+══════════════════════════════════════════════════════════
+  [IDENTICAL]   14 files (no change after normalization)
+  [DB-SPECIFIC]  2 files (db-variant differences only)
+  [EXCLUDED]     1 file  (.claude/skills/init-new-repository/)
+══════════════════════════════════════════════════════════
+
+Proceed? (Y to continue, N to cancel)
+```
+
+Conflicts marked with `(local newer:...)` or `(upstream newer:...)` should already be
+resolved before this table is shown (ask per-file in Step 2 before building the table).
+
+## Edge Cases
+
+**File renamed in one repo**: Will appear as NEW on one side + absent on the other. No
+automatic rename detection — it will create a PR that adds the new name on one side. The
+old name stays if present. This is acceptable for the current implementation.
+
+**Empty file**: Treat as a valid file. An empty file differs from an absent file.
+
+**Skill with both SKILL.md and supporting files (scripts, references/)**: All files under
+the skill directory are in scope together. If a skill is new on one side, all its files are
+pulled/pushed as a group.
+
+**Circular sync**: If the same change is already present (identical after normalization),
+it is classified as SKIP. Running the skill after PRs merge results in no changes (idempotent).
+
+**No changes detected**: Report "No sync needed — all in-scope files are identical after
+normalization" and exit without creating branches or PRs.

--- a/.claude/skills/sync-claude-config/references/token-mapping.md
+++ b/.claude/skills/sync-claude-config/references/token-mapping.md
@@ -1,0 +1,83 @@
+# Token Mapping Reference
+
+The `.claude/` files in rapid-go contain canonical identifiers. When `init-new-repository` creates a derived project, it replaces these identifiers with project-specific values (see `init-new-repository/scripts/init_repository.py` lines 631–651). The sync skill needs to reverse this mapping so normalized content from both sides is comparable.
+
+## Token Derivation (from the LOCAL project)
+
+Read these values from the LOCAL project before starting any comparison:
+
+| Token | Source |
+|-------|--------|
+| `{go-module}` | `go.mod` line 1: `module github.com/yourorg/yourproject` |
+| `{service-name}` | Directory name under `schema/proto/` — the one that is NOT `google` or `protoc-gen-openapiv2`. E.g. `schema/proto/myapp/` → `myapp` |
+| `{project-title}` | H1 heading in `.claude/CLAUDE.md`: `# MY PROJECT` |
+| `{buf-org}` | Registry URL in `buf.yaml` or `buf.gen.yaml`: `buf.build/{buf-org}/{service-name}` |
+| `{docker-network}` | Network name in `docker-compose.yml` (e.g. `myapp-network`) |
+| `{org}/{repo}` | `{go-module}` with `github.com/` stripped: `yourorg/yourproject` |
+| `{database}` | `mysql` if `db/mysql/` exists; `postgresql` if `db/postgresql/` exists |
+
+## Forward Map — Apply When Pulling (UPSTREAM → LOCAL)
+
+Replace rapid-go canonical tokens with local project values:
+
+| Find (canonical / rapid-go) | Replace with (local) |
+|-----------------------------|----------------------|
+| `github.com/abyssparanoia/rapid-go` | `{go-module}` |
+| `package rapid.` | `package {service-name}.` |
+| `import "rapid/` | `import "{service-name}/` |
+| `pb/rapid/` | `pb/{service-name}/` |
+| `buf.build/abyssparanoia/rapid` | `buf.build/{buf-org}/{service-name}` |
+| `rapid-go_rapid-go-network` | `{service-name}_{docker-network}` |
+| `rapid-go-network` | `{docker-network}` |
+| `# RAPID GO` | `# {project-title}` |
+| `RAPID GO` | `{project-title}` |
+| `./schema/openapi/rapid/` | `./schema/openapi/{service-name}/` |
+| `codebase investigation for rapid-go` | `codebase investigation for {service-name}` |
+| `Repository: abyssparanoia/rapid-go` | `Repository: {org}/{repo}` |
+
+## Reverse Map — Apply When Pushing (LOCAL → UPSTREAM)
+
+Replace local project values with rapid-go canonical tokens. This is the exact inverse:
+
+| Find (local) | Replace with (canonical / rapid-go) |
+|--------------|-------------------------------------|
+| `{go-module}` | `github.com/abyssparanoia/rapid-go` |
+| `package {service-name}.` | `package rapid.` |
+| `import "{service-name}/` | `import "rapid/` |
+| `pb/{service-name}/` | `pb/rapid/` |
+| `buf.build/{buf-org}/{service-name}` | `buf.build/abyssparanoia/rapid` |
+| `{service-name}_{docker-network}` | `rapid-go_rapid-go-network` |
+| `{docker-network}` | `rapid-go-network` |
+| `# {project-title}` | `# RAPID GO` |
+| `{project-title}` | `RAPID GO` |
+| `./schema/openapi/{service-name}/` | `./schema/openapi/rapid/` |
+| `codebase investigation for {service-name}` | `codebase investigation for rapid-go` |
+| `Repository: {org}/{repo}` | `Repository: abyssparanoia/rapid-go` |
+
+## Application Order (Critical)
+
+Apply replacements **longest/most-specific first** to avoid partial matches:
+
+1. `rapid-go_rapid-go-network` / `{service-name}_{docker-network}` — compound form first
+2. `rapid-go-network` / `{docker-network}` — simple form second
+3. `buf.build/abyssparanoia/rapid` / `buf.build/{buf-org}/{service-name}` — full registry URL first
+4. `github.com/abyssparanoia/rapid-go` / `{go-module}` — full module path
+5. `pb/rapid/` / `pb/{service-name}/` — pb path
+6. `./schema/openapi/rapid/` / `./schema/openapi/{service-name}/`
+7. `import "rapid/` / `import "{service-name}/`
+8. `package rapid.` / `package {service-name}.`
+9. `# RAPID GO` / `# {project-title}` — prefixed form first
+10. `RAPID GO` / `{project-title}` — plain form second (must come after prefixed)
+11. Remaining string replacements in any order
+
+## DB-Variant Content
+
+The DB choice (mysql vs postgresql) affects code examples in several files — these are NOT token-normalizable. Do **not** sync content where the only difference after token normalization is `mysql` ↔ `postgresql` in example code. Mark those as **skip — DB-specific**.
+
+Files most likely to have DB-variant differences:
+- `.claude/rules/repository.md` (backtick vs double-quote quoting of identifiers in ORDER BY examples)
+- `.claude/rules/dependency-injection.md` (import paths `infrastructure/mysql` vs `.../postgresql`)
+- `.claude/skills/add-domain-entity/references/*.md`
+- `.claude/skills/add-database-table/references/*.md`
+
+Detection: after token normalization, if the only remaining lines that differ contain `mysql`/`postgresql` as a substring (excluding comments that explain the difference), classify as DB-specific skip.


### PR DESCRIPTION
## Proposed Changes

- Add `.claude/skills/sync-claude-config/` skill for bidirectional `.claude/` content sync between rapid-go and derived projects
- Update `.claude/CLAUDE.md` Skills table with the new skill entry

## Implementation

### New files

- `.claude/skills/sync-claude-config/SKILL.md` — Main orchestration skill (6-step procedure)
- `.claude/skills/sync-claude-config/references/token-mapping.md` — Token derivation and forward/reverse replacement maps (the inverse of `init-new-repository`'s string substitution)
- `.claude/skills/sync-claude-config/references/sync-algorithm.md` — Classification algorithm, conflict resolution, exclusion list, and edge cases

### How it works

Run `/sync-claude-config` from a derived project that has rapid-go added via `claude --add-dir <rapid-go-path>`.

1. Reads LOCAL token values (module path, proto namespace, project title, buf registry, docker network) from the current project
2. Enumerates `.claude/` files in scope (`CLAUDE.md`, `rules/`, `skills/`, `agents/`, `commands/`; excludes `settings.local.json`, `worktrees/`, `init-new-repository/`)
3. Normalizes LOCAL content via the reverse token map so both sides are in rapid-go canonical form before comparison
4. Classifies each file: **pull** (rapid-go only), **push** (local only), **skip** (identical after normalization), or **conflict** (differs — resolved by git-commit-timestamp hint + user confirmation)
5. DB-variant differences (`mysql` vs `postgresql` in code examples) are detected and skipped rather than clobbered
6. After user confirmation, applies forward map when pulling and reverse map when pushing, then creates a PR in each repo that received changes

### After this merges

Other derived projects can run `/sync-claude-config` (with rapid-go added via `--add-dir`) to pull in any improvements that landed here.