### PR TITLE
Sync .claude/ config from robohouse

### DIFF
--- a/.claude/rules/domain-model.md
+++ b/.claude/rules/domain-model.md
@@ -50,26 +50,31 @@ type Example struct {
 | Reference data (lookup) | `ReadonlyReference` | Optional (via `Preload`) | Never written together |
 | Owned child entities | Direct field | Always loaded | Written together with parent |
 
-```go
-// ReadonlyReference - for reference/lookup relations
-type Example struct {
-    ID        string
-    TenantID  string
-    CreatedAt time.Time
+### Owned 1:1 Child Field Type Convention (New Entities)
 
-    // Tenant is reference data, not owned by Example
-    ReadonlyReference *struct {
-        Tenant *Tenant
-    }
+For **new** entities with optional owned 1:1 children (where the child may or may not exist), prefer `nullable.Type[ChildStruct]` over `*ChildStruct` pointer:
+
+```go
+// Good - nullable.Type for optional owned 1:1 child (new entities)
+type PaymentMethod struct {
+    ID         string
+    CreditCard nullable.Type[PaymentMethodCreditCard]  // Present when type=card
+    BankAccount nullable.Type[PaymentMethodBankAccount] // Present when type=bank
 }
 
-// Direct field - for owned/composed entities
-type Order struct {
-    ID        string
-    Items     OrderItems  // Always loaded, written together
-    CreatedAt time.Time
+// Acceptable for existing entities (pointer used historically)
+type PaymentMethod struct {
+    CreditCard  *PaymentMethodCreditCard   // Existing code — not required to migrate
+    BankAccount *PaymentMethodBankAccount
 }
 ```
+
+**Why `nullable.Type[T]` for new entities:**
+- Explicit `.Valid` flag prevents nil-dereference without nil checks
+- Consistent with other optional fields in the codebase
+- Clear semantics: `.Valid` = child exists, `.Value()` = access child data
+
+**Note:** Existing entities using `*ChildStruct` do not need to be migrated. Apply the `nullable.Type[T]` convention only when creating new owned 1:1 child relationships.
 
 ### Owned Child Entities – Cascade Requirements
 
@@ -95,6 +100,27 @@ type Order struct {
 type Staff struct {
     ID      string
     Profile nullable.Type[StaffProfile]
+}
+```
+
+```go
+// ReadonlyReference - for reference/lookup relations
+type Example struct {
+    ID        string
+    TenantID  string
+    CreatedAt time.Time
+
+    // Tenant is reference data, not owned by Example
+    ReadonlyReference *struct {
+        Tenant *Tenant
+    }
+}
+
+// Direct field - for owned/composed entities
+type Order struct {
+    ID        string
+    Items     OrderItems  // Always loaded, written together
+    CreatedAt time.Time
 }
 ```
 
@@ -368,6 +394,60 @@ func (k ExampleSortKey) Valid() bool {
 ### Default Value
 
 The default sort key is **always** `CreatedAtDesc`. This default is applied in the input layer constructor, not in the domain model.
+
+## Method Naming Convention
+
+All mutating methods on domain models follow a strict naming scheme based on **semantics**, not syntax.
+
+| Prefix / verb | Meaning | Signature | Examples |
+|---|---|---|---|
+| `Set{X}` | Fill a value that was previously empty (nullable/derived field, never overwrites meaningful state) | `*Entity` | `Invoice.SetStripe`, `InvoiceItem.SetStripe`, `InvoiceTax.SetStripe`, `Payment.SetStripe`, `Refund.SetStripe`, `Organization.SetStripe`, `Staff.SetImageURL` |
+| `Update` / `Update{Field}` | Overwrite an existing value with no domain ceremony | `*Entity` or `(*Entity, error)` if it validates | `Tenant.Update`, `Admin.Update`, `Staff.Update`, `Invoice.UpdatePaymentMethodID`, `PaymentMethod.UpdateIsDefault` |
+| Specific verb (`Finalize`, `MarkPaid`, `Void`, `Pay`, `Delete`…) | A domain state transition with business meaning | `(*Entity, error)` | `Invoice.Finalize`, `Payment.MarkSucceeded`, `PaymentMethod.Delete` |
+
+**Rule of thumb**: if the field was guaranteed empty before, it's `Set`; if you are replacing a possibly-meaningful value with a generic one, it's `Update`; if the change carries business meaning or guards a state machine, use a specific verb.
+
+### Return the Receiver
+
+**All mutating methods must return the receiver** (`*Entity`), and `(*Entity, error)` when they also validate a precondition. This enables chaining and ensures a consistent shape across the codebase.
+
+```go
+// Good - returns receiver
+func (m *Admin) Update(displayName null.String, t time.Time) *Admin {
+    if displayName.Valid { m.DisplayName = displayName.String }
+    m.UpdatedAt = t
+    return m
+}
+
+// Good - returns (receiver, error) when validating
+func (m *PaymentMethod) UpdateCreditCardDetails(...) (*PaymentMethod, error) {
+    if m.PaymentMethodType != PaymentMethodTypeCard {
+        return nil, errors.PaymentMethodTypeMismatchErr.New()...
+    }
+    // mutate
+    return m, nil
+}
+```
+
+Void mutators (`func (m *Entity) Mutate(...)`) are **forbidden** on domain models.
+
+### Validate Inside the Method
+
+If a precondition can be checked from the object's own state, the check belongs **inside the model method** (returning a domain error), never in the usecase/service immediately before the call. Duplicating it externally risks other callers missing it.
+
+### Predicates over Inline Field Inspection
+
+Usecase/service code must not branch on a model's raw exported fields. Expose an intent-revealing predicate on the model instead:
+
+```go
+// Bad - usecase inspects raw fields
+if inv.Status != model.InvoiceStatusDraft { return nil }
+
+// Good - model exposes a predicate
+if !inv.IsDraft() { return nil }
+```
+
+Common predicates: `IsDraft() bool`, `HasPaymentMethod(id string) bool`, `IsHostedURLAvailable() bool`, `IsStripe() bool`, `IsDownloadable() bool`.
 
 ## State Change Methods (Domain Logic First)
 

--- a/.claude/rules/grpc-handler.md
+++ b/.claude/rules/grpc-handler.md
@@ -380,6 +380,61 @@ func AdminInvitationToPb(m *model.AdminInvitation) *pb.AdminInvitation {
 - Code reviewers can more easily spot missing field mappings
 - Prevents accidental omission of nullable field handling
 
+### Direct Return for Simple Marshallers
+
+When there are no optional/nullable fields to declare as intermediate variables, **return the struct literal directly** without assigning to a temporary variable:
+
+```go
+// Good - direct return when no intermediate variables needed
+func PaymentMethodToPb(m *model.PaymentMethod) *pb.PaymentMethod {
+    if m == nil {
+        return nil
+    }
+    return &pb.PaymentMethod{
+        Id:   m.ID,
+        Type: PaymentMethodTypeToPb(m.PaymentMethodType),
+    }
+}
+
+// Bad - unnecessary temporary variable
+func PaymentMethodToPb(m *model.PaymentMethod) *pb.PaymentMethod {
+    if m == nil {
+        return nil
+    }
+    result := &pb.PaymentMethod{   // Don't do this when there's nothing to prepare
+        Id:   m.ID,
+        Type: PaymentMethodTypeToPb(m.PaymentMethodType),
+    }
+    return result
+}
+```
+
+**Rule:** Use intermediate `var` declarations only for nullable/optional fields (e.g., `null.Time`, optional timestamps). Use direct `return &pb.X{...}` for all other cases.
+
+### Mapping `null.String` / `null.Int64` → Optional Proto Fields
+
+For `null.String`, `null.Int64`, and similar `null.*` types (from `github.com/aarondl/null/v8`) that map to `optional` proto fields (which become `*string`, `*int64` in Go), **always use `.Ptr()` directly in the struct literal**. Do NOT declare an intermediate variable with a manual `if .Valid` block.
+
+```go
+// BAD - manual intermediate variable
+var paymentMethodID *string
+if m.PaymentMethodID.Valid {
+    paymentMethodID = &m.PaymentMethodID.String
+}
+result := &pb.Invoice{
+    PaymentMethodId: paymentMethodID,
+    InvoiceNumber:   ...,
+}
+
+// GOOD - inline .Ptr()
+result := &pb.Invoice{
+    PaymentMethodId: m.PaymentMethodID.Ptr(),
+    InvoiceNumber:   m.InvoiceNumber.Ptr(),
+}
+```
+
+**Exception**: `null.Time` → `*timestamppb.Timestamp` still requires a `var` block because conversion from `time.Time` → `*timestamppb.Timestamp` needs `timestamppb.New()`, which `.Ptr()` cannot provide. Use the `var` pattern for those only.
+
 ## Error Handling
 
 - Return errors directly from interactors

--- a/.claude/rules/proto-definition.md
+++ b/.claude/rules/proto-definition.md
@@ -77,6 +77,27 @@ service AdminV1Service {
 
 **Important**: This ordering applies to both `api.proto` service definitions and `api_{resource}.proto` message definitions.
 
+**New RPCs go at the END of the service block** — never insert them mid-list between existing RPCs. This minimizes merge conflicts and maintains a clear "arrival order" for reviewing history.
+
+```protobuf
+// BAD - inserted mid-service between UpdateMeOrganization and GetStaff
+service StaffV1Service {
+  rpc UpdateMeOrganization(...)  returns (...) {...}
+  rpc GetInvoice(...)   returns (...) {...}  // ← inserted here
+  rpc ListInvoices(...) returns (...) {...}  // ← inserted here
+  rpc GetStaff(...) returns (...) {...}
+}
+
+// GOOD - appended at end
+service StaffV1Service {
+  rpc UpdateMeOrganization(...) returns (...) {...}
+  rpc GetStaff(...) returns (...) {...}
+  // ... other existing RPCs ...
+  rpc GetInvoice(...)   returns (...) {...}  // ← new, at end
+  rpc ListInvoices(...) returns (...) {...}  // ← new, at end
+}
+```
+
 ## File Organization
 
 ### `api.proto` - Service Definition
@@ -186,6 +207,46 @@ message UpdateTenantRequest {
 - Place resource messages and enums here.
 - If you use `google.protobuf.Timestamp`, import `google/protobuf/timestamp.proto`.
 - Each resource requires **both Full and Partial message definitions** (see Partial Pattern section below).
+- **Owned child messages must be nested inside the parent message** (see Owned Child Nesting below).
+
+### Owned Child Message Nesting
+
+When a message is a **fully-owned child** (cannot exist independently of the parent — a composed 1:1 or 1:N relationship), define it as a **nested message** inside the parent. Top-level message definitions imply the type is reusable across multiple parents, which contradicts ownership semantics.
+
+```protobuf
+// BAD - top-level definition implies reuse / independence
+message InvoiceItem {
+  string id = 1;
+  // ...
+}
+message Invoice {
+  repeated InvoiceItem items = 15;  // ownership not visible in proto
+}
+
+// GOOD - nested definition encodes ownership structurally
+message Invoice {
+  // ...fields...
+
+  enum InvoiceItemType {
+    INVOICE_ITEM_TYPE_UNSPECIFIED = 0;
+    INVOICE_ITEM_TYPE_SUBSCRIPTION = 1;
+    // ...
+  }
+
+  message InvoiceItem {
+    string id = 1;
+    InvoiceItemType type = 2;
+    // ...
+  }
+
+  repeated InvoiceItem items = 15;
+  // option ...
+}
+```
+
+**Effect on generated Go code**: After `generate.buf`, nested types become `ParentMessage_ChildMessage` (e.g., `Invoice_InvoiceItem`) and nested enums become `ParentMessage_EnumName` (e.g., `Invoice_InvoiceItemType`). Update all Go references accordingly.
+
+**Rule**: Only use top-level messages for types that are genuinely shared across multiple parent resources (e.g., `Pagination`, `InvoiceStatus`).
 
 Example (admin staff):
 

--- a/.claude/rules/repository.md
+++ b/.claude/rules/repository.md
@@ -159,6 +159,39 @@ type BaseListOptions struct {
 }
 ```
 
+### IncludeDeleted Option on Get Queries
+
+For entities with soft-delete (`deleted_at` column), add `IncludeDeleted bool` directly to the entity's `Get{Entity}Query` struct (not in `BaseGetOptions`, since soft-delete is entity-specific):
+
+```go
+type GetPaymentMethodQuery struct {
+    BaseGetOptions
+    ID             null.String
+    ExternalID     null.String
+    OrganizationID null.String
+    IncludeDeleted bool  // When true, includes soft-deleted rows
+}
+```
+
+**When to use `IncludeDeleted: true`:**
+- Idempotency checks in webhook handlers — a soft-deleted row means the event was already processed (or the record was detached). Skip rather than re-create.
+- Restore workflows — look up a soft-deleted record to restore it.
+
+**Repository implementation pattern:**
+
+```go
+func (r *example) Get(ctx context.Context, query repository.GetExampleQuery) (*model.Example, error) {
+    mods := []qm.QueryMod{}
+
+    // Only filter out soft-deleted rows when IncludeDeleted is false
+    if !query.IncludeDeleted {
+        mods = append(mods, dbmodel.ExampleWhere.DeletedAt.IsNull())
+    }
+
+    // ... rest of query building
+}
+```
+
 ## Implementation (Infrastructure Layer)
 
 Location: `internal/infrastructure/{mysql|postgresql|spanner}/repository/{entity}.go`
@@ -268,23 +301,24 @@ func (r *example) buildListQuery(query repository.ListExamplesQuery) []qm.QueryM
 
 #### PostgreSQL Implementation
 
-PostgreSQL uses double quotes instead of backticks for identifiers:
+PostgreSQL uses double quotes instead of backticks for identifiers. Always reference `dbmodel.{Table}Columns.{Field}` constants instead of hardcoding column name strings — this prevents silent breaks when columns are renamed.
 
 ```go
 func (r *example) List(ctx context.Context, query repository.ListExamplesQuery) (model.Examples, error) {
     mods := r.buildListQuery(query)
 
     // Sorting (BEFORE pagination)
+    // IMPORTANT: Use dbmodel column constants, never hardcode string literals
     if query.SortKey.Valid && query.SortKey.Value().Valid() {
         switch query.SortKey.Value() {
         case model.ExampleSortKeyCreatedAtDesc:
-            mods = append(mods, qm.OrderBy("\"created_at\" DESC"))
+            mods = append(mods, qm.OrderBy("\""+dbmodel.ExampleColumns.CreatedAt+"\" DESC"))
         case model.ExampleSortKeyCreatedAtAsc:
-            mods = append(mods, qm.OrderBy("\"created_at\" ASC"))
+            mods = append(mods, qm.OrderBy("\""+dbmodel.ExampleColumns.CreatedAt+"\" ASC"))
         case model.ExampleSortKeyNameAsc:
-            mods = append(mods, qm.OrderBy("\"name\" ASC"))
+            mods = append(mods, qm.OrderBy("\""+dbmodel.ExampleColumns.Name+"\" ASC"))
         case model.ExampleSortKeyNameDesc:
-            mods = append(mods, qm.OrderBy("\"name\" DESC"))
+            mods = append(mods, qm.OrderBy("\""+dbmodel.ExampleColumns.Name+"\" DESC"))
         case model.ExampleSortKeyUnknown:
             return nil, errors.InternalErr.Errorf("invalid sort key: %s", query.SortKey.Value())
         }
@@ -344,6 +378,40 @@ func (r *example) addPreload(mods []qm.QueryMod) []qm.QueryMod {
     return mods
 }
 ```
+
+### Owned Children vs Reference Relations — Unconditional Preload
+
+`Preload bool` in `BaseGetOptions` / `BaseListOptions` controls loading of **reference** relations (e.g., `ReadonlyReference.Tenant`). It does NOT apply to **fully-owned child entities**.
+
+| Relation Type | Load Condition | Example |
+|---|---|---|
+| Reference (lookup) | Conditional — only when `Preload: true` | `InvoiceRels.Organization` |
+| Owned 1:N child | **Unconditional — always load** | `InvoiceRels.InvoiceItems` |
+| Owned 1:1 child | **Unconditional — always load** | `InvoiceRels.InvoiceStripe` |
+
+**Fully-owned children** (entities that cannot exist without their parent and are part of the same aggregate) **must always be loaded** regardless of the `Preload` flag. Never use a boolean parameter to gate their loading:
+
+```go
+// BAD - conditional preload of owned child
+func (r *invoice) buildPreload(preloadStripe bool) []qm.QueryMod {
+    mods := []qm.QueryMod{qm.Load(dbmodel.InvoiceRels.InvoiceItems)}
+    if preloadStripe {
+        mods = append(mods, qm.Load(dbmodel.InvoiceRels.InvoiceStripe))
+    }
+    return mods
+}
+
+// GOOD - always load owned children
+func (r *invoice) buildPreload() []qm.QueryMod {
+    return []qm.QueryMod{
+        qm.Load(dbmodel.InvoiceRels.InvoiceItems),
+        qm.Load(dbmodel.InvoiceRels.InvoiceStripe),
+        qm.Load(fmt.Sprintf("%s.%s", dbmodel.InvoiceRels.InvoiceItems, dbmodel.InvoiceItemRels.InvoiceItemStripe)),
+    }
+}
+```
+
+**Why**: The API handler may not surface the owned children today, but the domain model is incomplete without them. Conditional loading causes nil-dereference bugs and makes behavior dependent on call-site flags.
 
 ## Marshaller (Infrastructure Layer)
 
@@ -445,6 +513,36 @@ func InvitationToModel(i *dbmodel.Invitation) *model.Invitation {
 - Prevents accidentally omitting fields in struct literal
 - Makes nullable field handling visible and reviewable
 
+### Struct Literal Return Rule
+
+All conversion functions must return the struct using a struct literal with all fields explicitly listed. Do **not** initialize an empty struct and then assign fields one by one.
+
+```go
+// GOOD - struct literal return
+func ExampleToModel(e *dbmodel.Example) *model.Example {
+    return &model.Example{
+        ID:        e.ID,
+        TenantID:  e.TenantID,
+        Name:      e.Name,
+        Status:    model.ExampleStatus(e.Status),
+        CreatedAt: e.CreatedAt,
+        UpdatedAt: e.UpdatedAt,
+        ReadonlyReference: nil,
+    }
+}
+
+// BAD - field-by-field assignment on empty struct
+func ExampleToModel(e *dbmodel.Example) *model.Example {
+    m := &model.Example{}
+    m.ID = e.ID
+    m.TenantID = e.TenantID
+    m.Name = e.Name
+    return m
+}
+```
+
+**Exception**: When conditional field assignment is required (e.g., `ReadonlyReference` populated only when `e.R != nil`, or nullable timestamps), use the `var` declaration pattern described above, then build the struct literal with the prepared variables.
+
 ### Slice Version
 
 ```go
@@ -475,32 +573,6 @@ func ExampleToDBModel(m *model.Example) *dbmodel.Example {
 ```
 
 **Note**: `ReadonlyReference` is never converted back to DB model - it's read-only.
-
-### Struct Literal Return Rule
-
-**All conversion functions must use struct literal initialization in the return statement.** Do not create an empty struct and assign fields one by one.
-
-```go
-// GOOD - struct literal with all fields
-func TenantToModel(s *dbmodel.Tenant) *model.Tenant {
-    return &model.Tenant{
-        ID:                s.ID,
-        Name:              s.Name,
-        ReadonlyReference: nil,
-    }
-}
-
-// BAD - field-by-field assignment
-func TenantToModel(s *dbmodel.Tenant) *model.Tenant {
-    m := &model.Tenant{}
-    m.ID = s.ID
-    m.Name = s.Name
-    m.ReadonlyReference = nil
-    return m
-}
-```
-
-**Exception**: When conditional assignment is needed (e.g., `ReadonlyReference`, nullable timestamps), use `m := &XXX{...}` with all non-conditional fields in the literal, then conditional blocks, then `return m`.
 
 ## Transaction Context
 

--- a/.claude/rules/specification.md
+++ b/.claude/rules/specification.md
@@ -1,0 +1,87 @@
+# Specification Document Guidelines
+
+## Overview
+
+Rules for writing specification documents placed under `docs/specifications/`.
+
+## File Rules
+
+- Format: **Markdown** (`.md`)
+- Location: `docs/specifications/`
+- File name: **English kebab-case** (e.g., `organization-registration-flow.md`)
+- **Split files per flow** — do not combine multiple flows into one file
+
+## Writing Rules
+
+| Item | Rule |
+|------|------|
+| Title | English (H1 heading) |
+| Body | Written in Japanese |
+| Overview section | Required — explain the purpose in ~3 sentences |
+| Diagrams | Must include a sequence diagram or flowchart (use mermaid) |
+| Status transitions | If status transitions exist, must include a state diagram (mermaid stateDiagram) |
+| Length | Keep concise — do not include implementation details (code, SQL, etc.) |
+
+## Section Structure
+
+```
+# {Flow Name}
+
+## 概要
+
+(~3 sentences describing purpose, actor, and trigger)
+
+## 前提条件
+
+(Actor, required permissions, dependent data, etc.)
+
+## フロー
+
+(Sequence diagram or flowchart + brief notes per step)
+
+## ステータス遷移 (if applicable)
+
+(State diagram)
+
+## 備考
+
+(Constraints, security considerations, downstream flows, etc.)
+```
+
+## Diagram Syntax
+
+### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+  Actor ->> System: action
+  System ->> DB: query
+  DB -->> System: result
+  System -->> Actor: response
+```
+
+### Flowchart
+
+```mermaid
+flowchart TD
+  A[Start] --> B{Condition}
+  B -- Yes --> C[Process]
+  B -- No --> D[End]
+```
+
+### State Diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> pending
+  pending --> accepted
+  pending --> rejected
+  pending --> invalidated
+```
+
+## What NOT to Include
+
+- Implementation code or SQL
+- Infrastructure configuration details
+- Content duplicated in other specification documents
+- Unconfirmed specs — if uncertain, note "TBD" in the 備考 section

--- a/.claude/rules/usecase-interactor.md
+++ b/.claude/rules/usecase-interactor.md
@@ -54,6 +54,32 @@ type AdminStaffInteractor interface {
 
 **Implementation file methods must follow the same order.**
 
+## No Raw Field Inspection on Domain Models
+
+Interactors must not branch on a domain model's raw exported fields or status. Expose an intent-revealing predicate on the model and call that instead.
+
+```go
+// Bad - usecase inspects raw fields
+if inv.Status != model.InvoiceStatusDraft {
+    logger.L(ctx).Info("already finalized (idempotent)")
+    return nil
+}
+
+// Good - call a model predicate
+if !inv.IsDraft() {
+    logger.L(ctx).Info("already finalized (idempotent)")
+    return nil
+}
+
+// Bad - inline composite guard
+if !invoice.IsStripe() || !invoice.IsDownloadable() || !invoice.Stripe.Valid { ... }
+
+// Good - single predicate
+if !invoice.IsHostedURLAvailable() { ... }
+```
+
+See `domain-model.md` → **Method Naming Convention** for the full list of predicates and the naming rules for model methods.
+
 ## No Private Methods
 
 Interactor implementations must **not** define private methods. Only public interface methods are implemented.
@@ -814,33 +840,44 @@ if param.Role.Valid {
 
 ## Domain Method Usage (Domain Logic First)
 
-**IMPORTANT**: All domain model operations (creation and state changes) MUST use domain model constructors and methods. Never directly initialize structs or assign fields in the usecase layer.
+**IMPORTANT**: Always use domain constructors and methods. Never directly initialize domain model structs or assign fields in the usecase layer.
 
-### Creation: Use Constructors
+### Creation: Use Domain Constructors
 
 ```go
 // GOOD - use domain constructor
-staff := model.NewStaff(param.TenantID, param.Role, param.AuthUID, param.DisplayName, param.ImagePath, param.Email, param.RequestTime)
+func (i *adminStaffInteractor) Create(ctx context.Context, param *input.AdminCreateStaff) (*model.Staff, error) {
+    staff := model.NewStaff(param.TenantID, param.Role, param.AuthUID, param.DisplayName, param.ImagePath, param.Email, param.RequestTime)
+    // ...
+}
 
 // BAD - direct struct initialization in usecase
-staff := &model.Staff{
-    ID:          id.New(),
-    TenantID:    param.TenantID,
-    Role:        param.Role,
-    CreatedAt:   param.RequestTime,
-    UpdatedAt:   param.RequestTime,
+func (i *adminStaffInteractor) Create(ctx context.Context, param *input.AdminCreateStaff) (*model.Staff, error) {
+    staff := &model.Staff{
+        ID:          id.New(),
+        TenantID:    param.TenantID,
+        Role:        param.Role,
+        DisplayName: param.DisplayName,
+    }
+    // ...
 }
 ```
+
+**Why**: Constructors encapsulate ID generation, default values, and field constraints. Direct initialization bypasses these guarantees.
 
 ### Updates: Use Domain Methods
 
 ```go
-// GOOD
-admin.UpdateRole(param.Role.Value(), param.RequestTime)
+// GOOD - use domain method
+if param.Role.Valid {
+    admin.UpdateRole(param.Role.Value(), param.RequestTime)
+}
 
-// BAD - direct field assignment
-admin.Role = param.Role.Value()
-admin.UpdatedAt = param.RequestTime
+// BAD - direct field assignment in usecase
+if param.Role.Valid {
+    admin.Role = param.Role.Value()
+    admin.UpdatedAt = param.RequestTime
+}
 ```
 
 See `domain-model.md` for more details on domain method patterns.

--- a/.claude/rules/webhook-implementation.md
+++ b/.claude/rules/webhook-implementation.md
@@ -20,7 +20,7 @@ External Service → HTTP Server → Custom HTTP Handler → Internal gRPC → g
 ## Directory Structure
 
 ```
-schema/proto/rapid/
+schema/proto/oshipo/
 └── webhook_api/v1/              # Separate package for webhook definitions
     ├── api.proto                # Service definition
     └── api_{service}.proto      # Request/Response messages
@@ -48,17 +48,17 @@ internal/
 
 ### Step 1: Proto Definitions
 
-Create webhook-specific proto package in `schema/proto/rapid/webhook_api/v1/`.
+Create webhook-specific proto package in `schema/proto/oshipo/webhook_api/v1/`.
 
 #### Service Definition (api.proto)
 
 ```protobuf
 syntax = "proto3";
 
-package rapid.webhook_api.v1;
+package oshipo.webhook_api.v1;
 
 import "google/api/annotations.proto";
-import "rapid/webhook_api/v1/api_{service}.proto";
+import "oshipo/webhook_api/v1/api_{service}.proto";
 
 service WebhookService {
   rpc Receive{Service}Webhook(Receive{Service}WebhookRequest) returns (Receive{Service}WebhookResponse) {
@@ -80,7 +80,7 @@ service WebhookService {
 ```protobuf
 syntax = "proto3";
 
-package rapid.webhook_api.v1;
+package oshipo.webhook_api.v1;
 
 import "protoc-gen-openapiv2/options/annotations.proto";
 
@@ -179,8 +179,8 @@ func (p *WebhookReceive{Service}) Validate() error {
 package webhook
 
 import (
-    webhook_apiv1 "github.com/abyssparanoia/rapid-go/internal/infrastructure/grpc/pb/rapid/webhook_api/v1"
-    "github.com/abyssparanoia/rapid-go/internal/usecase"
+    webhook_apiv1 "github.com/Mirrativ-com/livedx-oshipo-server/internal/infrastructure/grpc/pb/oshipo/webhook_api/v1"
+    "github.com/Mirrativ-com/livedx-oshipo-server/internal/usecase"
 )
 
 type WebhookHandler struct {
@@ -206,10 +206,10 @@ import (
     "context"
     "time"
 
-    webhook_apiv1 "github.com/abyssparanoia/rapid-go/internal/infrastructure/grpc/pb/rapid/webhook_api/v1"
-    "github.com/abyssparanoia/rapid-go/internal/pkg/logger"
-    "github.com/abyssparanoia/rapid-go/internal/pkg/logger/logger_field"
-    "github.com/abyssparanoia/rapid-go/internal/usecase/input"
+    webhook_apiv1 "github.com/Mirrativ-com/livedx-oshipo-server/internal/infrastructure/grpc/pb/oshipo/webhook_api/v1"
+    "github.com/Mirrativ-com/livedx-oshipo-server/internal/pkg/logger"
+    "github.com/Mirrativ-com/livedx-oshipo-server/internal/pkg/logger/logger_field"
+    "github.com/Mirrativ-com/livedx-oshipo-server/internal/usecase/input"
     "go.uber.org/zap"
 )
 
@@ -278,8 +278,8 @@ import (
     "net/http"
     "strconv"
 
-    webhook_apiv1 "github.com/abyssparanoia/rapid-go/internal/infrastructure/grpc/pb/rapid/webhook_api/v1"
-    "github.com/abyssparanoia/rapid-go/internal/pkg/logger"
+    webhook_apiv1 "github.com/Mirrativ-com/livedx-oshipo-server/internal/infrastructure/grpc/pb/oshipo/webhook_api/v1"
+    "github.com/Mirrativ-com/livedx-oshipo-server/internal/pkg/logger"
     "go.uber.org/zap"
     "google.golang.org/grpc"
 )
@@ -397,7 +397,7 @@ Location: `internal/infrastructure/grpc/run.go`
 ```go
 import (
     // ... existing imports
-    webhook_apiv1 "github.com/abyssparanoia/rapid-go/internal/infrastructure/grpc/pb/rapid/webhook_api/v1"
+    webhook_apiv1 "github.com/Mirrativ-com/livedx-oshipo-server/internal/infrastructure/grpc/pb/oshipo/webhook_api/v1"
 )
 
 func NewServer(...) *grpc.Server {
@@ -433,6 +433,51 @@ if err = grpcGateway.HandlePath(
 **Path Conventions:**
 - External webhook path: `/v1/webhook/{service}` (e.g., `/v1/webhook/app-driver`)
 - Internal gRPC path: `/v1/webhook/{service}-internal` (not exposed externally)
+
+## Webhook Usecase Locking and Idempotency Patterns
+
+### Always Use `ForUpdate: true` Inside RWTx
+
+All repository `Get` calls inside a webhook `RWTx` handler **must** use `ForUpdate: true`. This prevents duplicate processing when multiple webhook events arrive for the same entity concurrently.
+
+```go
+func (i *webhookInteractor) ReceiveSomeEvent(ctx context.Context, param *input.WebhookSomeEvent) error {
+    return i.transactable.RWTx(ctx, func(ctx context.Context) error {
+        entity, err := i.entityRepository.Get(ctx, repository.GetEntityQuery{
+            ExternalID: null.StringFrom(param.ExternalID),
+            BaseGetOptions: repository.BaseGetOptions{
+                OrFail:    false,
+                ForUpdate: true,  // REQUIRED inside RWTx for webhook handlers
+            },
+        })
+        // ...
+    })
+}
+```
+
+### Use `IncludeDeleted: true` for Idempotency Checks
+
+When checking whether an entity was already created (idempotency guard), use `IncludeDeleted: true` so that a previously soft-deleted row is also treated as "already processed" and skipped:
+
+```go
+// Idempotency check - include soft-deleted rows to avoid re-creating
+existing, err := i.paymentMethodRepository.Get(ctx, repository.GetPaymentMethodQuery{
+    ExternalID: null.StringFrom(param.ExternalID),
+    BaseGetOptions: repository.BaseGetOptions{
+        OrFail:    false,
+        ForUpdate: true,
+    },
+    IncludeDeleted: true,  // Soft-deleted = already processed; skip
+})
+if err != nil {
+    return err
+}
+if existing != nil {
+    return nil // Idempotent
+}
+```
+
+**Why:** A soft-deleted record means the entity was previously processed and then deleted (e.g., detached). Re-creating it from a delayed duplicate webhook would corrupt state.
 
 ## Common Patterns
 
@@ -930,13 +975,13 @@ func (i *interactor) Receive(...) error {
 
 ```go
 // Bad - Webhook in public_api package
-package rapid.public_api.v1;
+package oshipo.public_api.v1;
 service PublicV1Service {
     rpc ReceiveWebhook(...) returns (...);
 }
 
 // Good - Separate webhook_api package
-package rapid.webhook_api.v1;
+package oshipo.webhook_api.v1;
 service WebhookService {
     rpc ReceiveWebhook(...) returns (...);
 }

--- a/.claude/rules/worker-pattern.md
+++ b/.claude/rules/worker-pattern.md
@@ -92,8 +92,8 @@ package input
 import (
     "time"
 
-    "github.com/abyssparanoia/rapid-go/internal/domain/errors"
-    "github.com/abyssparanoia/rapid-go/internal/pkg/validation"
+    "github.com/eaglys-platform/pandlock-api/internal/domain/errors"
+    "github.com/eaglys-platform/pandlock-api/internal/pkg/validation"
 )
 
 type TaskProcessProjectKeyCreation struct {
@@ -134,8 +134,8 @@ package usecase
 import (
     "context"
 
-    "github.com/abyssparanoia/rapid-go/internal/domain/model"
-    "github.com/abyssparanoia/rapid-go/internal/usecase/input"
+    "github.com/eaglys-platform/pandlock-api/internal/domain/model"
+    "github.com/eaglys-platform/pandlock-api/internal/usecase/input"
 )
 
 //go:generate go run go.uber.org/mock/mockgen -source=$GOFILE -destination=mock/$GOFILE -package=mock_usecase
@@ -164,9 +164,9 @@ package usecase
 import (
     "context"
 
-    "github.com/abyssparanoia/rapid-go/internal/domain/model"
-    "github.com/abyssparanoia/rapid-go/internal/domain/repository"
-    "github.com/abyssparanoia/rapid-go/internal/usecase/input"
+    "github.com/eaglys-platform/pandlock-api/internal/domain/model"
+    "github.com/eaglys-platform/pandlock-api/internal/domain/repository"
+    "github.com/eaglys-platform/pandlock-api/internal/usecase/input"
     "github.com/aarondl/null/v8"
 )
 
@@ -359,9 +359,9 @@ import (
     "time"
 
     "github.com/aws/aws-sdk-go-v2/service/sqs/types"
-    "github.com/abyssparanoia/rapid-go/internal/domain/errors"
-    "github.com/abyssparanoia/rapid-go/internal/usecase"
-    "github.com/abyssparanoia/rapid-go/internal/usecase/input"
+    "github.com/eaglys-platform/pandlock-api/internal/domain/errors"
+    "github.com/eaglys-platform/pandlock-api/internal/usecase"
+    "github.com/eaglys-platform/pandlock-api/internal/usecase/input"
 )
 
 type ProjectKeyCreationMessage struct {
@@ -428,7 +428,7 @@ Location: `internal/infrastructure/cmd/internal/worker_cmd/cmd.go`
 package worker_cmd
 
 import (
-    "github.com/abyssparanoia/rapid-go/internal/infrastructure/cmd/internal/worker_cmd/project_key_creation_cmd"
+    "github.com/eaglys-platform/pandlock-api/internal/infrastructure/cmd/internal/worker_cmd/project_key_creation_cmd"
     "github.com/spf13/cobra"
 )
 
@@ -462,12 +462,12 @@ import (
     "time"
 
     "github.com/caarlos0/env/v11"
-    "github.com/abyssparanoia/rapid-go/internal/infrastructure/dependency"
-    "github.com/abyssparanoia/rapid-go/internal/infrastructure/environment"
-    "github.com/abyssparanoia/rapid-go/internal/infrastructure/sqs"
-    "github.com/abyssparanoia/rapid-go/internal/infrastructure/sqs/handler"
-    "github.com/abyssparanoia/rapid-go/internal/infrastructure/sqs/subscriber"
-    "github.com/abyssparanoia/rapid-go/internal/pkg/logger"
+    "github.com/eaglys-platform/pandlock-api/internal/infrastructure/dependency"
+    "github.com/eaglys-platform/pandlock-api/internal/infrastructure/environment"
+    "github.com/eaglys-platform/pandlock-api/internal/infrastructure/sqs"
+    "github.com/eaglys-platform/pandlock-api/internal/infrastructure/sqs/handler"
+    "github.com/eaglys-platform/pandlock-api/internal/infrastructure/sqs/subscriber"
+    "github.com/eaglys-platform/pandlock-api/internal/pkg/logger"
     "github.com/spf13/cobra"
     "go.uber.org/zap"
 )
@@ -609,7 +609,7 @@ Location: `internal/infrastructure/cmd/root.go`
 
 ```go
 import (
-    "github.com/abyssparanoia/rapid-go/internal/infrastructure/cmd/internal/worker_cmd"
+    "github.com/eaglys-platform/pandlock-api/internal/infrastructure/cmd/internal/worker_cmd"
 )
 
 func NewCmdRoot() *cobra.Command {
@@ -664,7 +664,7 @@ func (s *Subscriber) processMessage(ctx context.Context, message types.Message) 
 }
 ```
 
-## kumo Setup (Development)
+## LocalStack Setup (Development)
 
 ### Docker Compose Configuration
 
@@ -673,42 +673,24 @@ Location: `docker-compose.yml`
 ```yaml
 services:
   aws:
-    image: ghcr.io/sivchari/kumo:latest
-    volumes:
-      - ./emulator/aws/data:/data
+    build: ./localstack
     environment:
-      KUMO_DATA_DIR: /data
-    ports:
-      - 4566:4566
+      SERVICES: s3,sns,sqs # Enable SQS service
+      AWS_DEFAULT_REGION: ap-northeast-1
 ```
 
 ### Initialization Script
 
-Location: `emulator/aws/script/init.sh`
-
-Unlike LocalStack, kumo does not have an auto-exec `ready.d` hook. Run the init script manually via Make:
-
-```bash
-make init.local.aws
-```
-
-To add SQS queues, extend the init script:
+Location: `localstack/script/init.sh`
 
 ```bash
 #!/bin/sh
 
-# Wait for kumo readiness
-for i in $(seq 1 30); do
-  if aws --endpoint-url=http://localhost:4566 s3 ls 2>/dev/null; then
-    break
-  fi
-  sleep 2
-done
-
+echo "SQS setup start!"
 echo "Creating SQS queues..."
 
 # Create queue for project key creation
-aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name project-key-creation
+aws --endpoint-url=http://aws:4566 sqs create-queue --queue-name project-key-creation
 echo 'project-key-creation queue created!'
 
 echo "SQS setup Done!"
@@ -771,7 +753,7 @@ source .envrc
 ### Manual Testing
 
 ```bash
-# Send test message (kumo)
+# Send test message (LocalStack)
 aws --endpoint-url=http://localhost:4566 sqs send-message \
   --queue-url http://localhost:4566/000000000000/project-key-creation \
   --message-body '{"project_id": "test-project-123"}'

--- a/.claude/skills/fix-review-comments/SKILL.md
+++ b/.claude/skills/fix-review-comments/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: fix-review-comments
-description: Fetch unresolved GitHub PR review comments and automatically fix the code, commit, and push. Use when: (1) running '/fix-review-comments', (2) asked to "fix review comments", "address PR comments", "respond to review", or similar. Can target the PR for the current branch, or a specific PR number (e.g. '/fix-review-comments 123'). Skips already-resolved threads and discussion-only comments that require no code change. Also updates Claude rules and review-diff anti-patterns when a comment reveals a missing convention.
+description: Fetch unresolved GitHub PR review comments and automatically fix the code. Use when: (1) running '/fix-review-comments', (2) asked to "fix review comments", "address PR comments", "respond to review", or similar. Can target the PR for the current branch, or a specific PR number (e.g. '/fix-review-comments 123'). Skips already-resolved threads and discussion-only comments that require no code change.
 ---
 
 # Fix Review Comments
 
-Fetch unresolved PR review threads, fix code, update rules if needed, then commit and push.
+Fetch unresolved PR review threads and fix the code automatically.
 
 ## Step 1: Detect PR
 
 ```bash
 # From current branch (no argument)
-gh pr view --json number,url,headRefName | jq -r '"#\(.number) \(.url) \(.headRefName)"'
+gh pr view --json number,url | jq -r '"#\(.number) \(.url)"'
 
 # Or use the number passed as argument
 ```
@@ -78,37 +78,33 @@ For each thread requiring a fix:
 
 Fix all actionable threads before running any verification.
 
-## Step 5: Update Rules (if applicable)
+## Step 5: Update Rules
 
-After fixing code, evaluate whether any comment reveals a **missing or incomplete coding convention** that should be captured in project rules. Ask:
+After fixing the code, evaluate whether any review comment reveals a **missing or incomplete coding convention** in the project rules.
 
-- Could this mistake recur if the rule isn't documented?
-- Is it a pattern-level issue (not just a one-off typo)?
+**When to update rules:**
+- The reviewer points out a pattern that is not documented in `.claude/rules/*.md`
+- The reviewer identifies an AI anti-pattern that is not in `ai-antipatterns.md`
+- The fix represents a recurring mistake AI models make
 
-If yes, update the appropriate file(s):
+**Rule file mapping:**
 
-| Comment type | Target file |
+| Comment topic | Target rule file |
 |---|---|
-| AI-generated code pattern mistake | `.claude/skills/review-diff/references/ai-antipatterns.md` — add new numbered pattern, renumber subsequent |
-| Domain model / entity convention | `.claude/rules/domain-model.md` |
-| Repository / marshaller pattern | `.claude/rules/repository.md` |
-| Usecase / interactor convention | `.claude/rules/usecase-interactor.md` |
-| gRPC handler pattern | `.claude/rules/grpc-handler.md` |
-| Testing convention | `.claude/rules/testing.md` |
-| Proto definition style | `.claude/rules/proto-definition.md` |
-| Other layer-specific rule | Corresponding `.claude/rules/*.md` |
+| Domain model (constructor, state transition, enum) | `.claude/rules/domain-model.md` |
+| Repository query, marshaller | `.claude/rules/repository.md` |
+| Usecase interactor (transaction, locking, IdP sync) | `.claude/rules/usecase-interactor.md` |
+| gRPC handler, marshaller | `.claude/rules/grpc-handler.md` |
+| Proto definition | `.claude/rules/proto-definition.md` |
+| Test patterns (mock, table-driven) | `.claude/rules/testing.md` |
+| Common AI mistakes (any layer) | `.claude/skills/review-diff/references/ai-antipatterns.md` |
 
-When adding to `ai-antipatterns.md`:
-1. Assign the next sequential number
-2. Include BAD/GOOD code examples from the actual review comment
-3. Renumber all subsequent patterns
-4. Update `.claude/skills/review-diff/SKILL.md` priority list if the pattern is critical
-
-When adding to `.claude/rules/*.md`:
-1. Add the rule in the appropriate section
-2. Follow the existing format (tables, code blocks, etc.)
-
-**Do NOT update rules for**: one-off typos, project-specific business logic, or comments that are already covered by existing rules.
+**If updating `ai-antipatterns.md`:**
+1. Assign the next sequential number (check current highest)
+2. Add a new section `### N. Description` with BAD/GOOD examples and **Why**
+3. Renumber `SKILL.md` priority list and `checklists.md` if the pattern number shifts existing ones
+4. Add the new pattern number to the `review-diff/SKILL.md` priority patterns list
+5. Add a checklist item to `review-diff/references/checklists.md` in the relevant section
 
 ## Step 6: Verify
 
@@ -123,20 +119,22 @@ Run tests if logic changed:
 
 ## Step 7: Commit and Push
 
-Stage, commit, and push all changes (code fixes + rule updates):
+Stage all changed files and commit. If code fixes and rule updates are logically separate, consider two commits:
 
 ```bash
-git add -A
-git commit -m "fix: address PR review comments
+# Option A: single commit
+git add <changed files>
+git commit -m "fix: address PR review comments"
 
-- <summary of code fixes>
-- <summary of rule updates, if any>"
+# Option B: two commits when rules were also updated
+git add <code files>
+git commit -m "fix: address PR review comments"
+
+git add .claude/
+git commit -m "docs: update rules based on review feedback"
+
 git push
 ```
-
-If code fixes and rule updates are logically separate, use two commits:
-1. Code fixes first: `fix: address PR #NNN review comments`
-2. Rule updates second: `docs: update rules from PR #NNN review feedback`
 
 ## Step 8: Report
 
@@ -150,9 +148,8 @@ PR: #NNN
    Comment: "@author: ..."
 
 ### Rules Updated (N)
-1. `.claude/rules/xxx.md` — added rule about ...
-   Triggered by: "@author: ..." comment on `path/to/file.go`
-2. `.claude/skills/review-diff/references/ai-antipatterns.md` — added #NN: ...
+1. `.claude/rules/foo.md` — added rule about X
+2. `.claude/skills/review-diff/references/ai-antipatterns.md` — added anti-pattern #N: Y
 
 ### Skipped (N)
 1. `path/to/file.go:line` — reason (already resolved / discussion / no code change needed)

--- a/.claude/skills/review-diff/SKILL.md
+++ b/.claude/skills/review-diff/SKILL.md
@@ -1,205 +1,122 @@
 ---
 name: review-diff
-description: Review and auto-fix code changes against project conventions by diffing the current branch against the default branch (main/master). Use when: (1) asked to review current changes, (2) running '/review-diff', (3) after completing a feature implementation and wanting to catch issues before creating a PR. Launches 5 specialized review agents in parallel (spec, convention, bug, security/performance, test quality), aggregates findings, and automatically fixes all issues found. Does NOT require an existing PR.
+description: Review and auto-fix code changes against project conventions by diffing the current branch against the default branch (main). Use when: (1) asked to review current changes, (2) running '/review-diff', (3) after completing a feature implementation and wanting to catch issues before creating a PR. Reviews all changed files against .claude/rules/, detects common AI coding mistakes (gomock.Any() misuse, missing ForUpdate, missing Preload, direct field assignment, wrong method ordering, etc.), and automatically fixes all issues found. Does NOT require an existing PR.
 ---
 
-# Diff Review & Auto-Fix (Parallel Agent Edition)
+# Diff Review & Auto-Fix
 
-Review current branch changes against main/master using **5 specialized parallel agents**, then **automatically fix all issues found**.
+Review current branch changes against main and **automatically fix all issues found**.
 
 ## Workflow
 
 ```
-1. Detect Default Branch  → find main or master
-2. Gather Changes         → git diff, changed files, classify
-3. Parallel Agent Review  → launch 5 agents simultaneously
-4. Aggregate Findings     → collect, deduplicate, sort
+1. Detect Default Branch  → find main
+2. Gather Changes         → git diff, changed files
+3. AI Anti-Pattern Check  → detect common AI mistakes
+4. Rule-Based Review      → apply rule checklists per file category
 5. Auto-Fix Issues        → edit files to fix all found problems
 6. Verify Fixes           → lint, tests, code generation
-7. Report                 → summary with agent-level breakdown
+7. Report                 → summary of what was found and fixed
 ```
 
 ## Step 1: Detect Default Branch
 
 ```bash
+# Try to detect
 git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||'
 ```
 
-If that fails, try `origin/main` first, then `origin/master`. Store the result as `$BASE`.
+If that fails, use `origin/main`.
 
-## Step 2: Gather Changes + Classify
+## Step 2: Gather Changes
 
 ```bash
-BASE=origin/main  # or origin/master
+BASE=origin/main
 
-# Changed files list
+# Changed files
 git diff --name-only $BASE...HEAD
 
-# Check if test files are included
-git diff --name-only $BASE...HEAD | grep '_test\.go$'
+# Full diff for review
+git diff $BASE...HEAD
 
-# Commit history for spec-reviewer context
+# Commit history
 git log $BASE...HEAD --oneline
 ```
 
-Note the changed file list — this is passed to agents in their prompts.
+## Step 3: AI Anti-Pattern Check
 
-Determine which agents to launch:
-- **spec-reviewer**: Always (spec compliance)
-- **convention-reviewer**: Always (convention & rules compliance)
-- **bug-reviewer**: Always (bug & anti-pattern detection)
-- **security-perf-reviewer**: Always (security & performance)
-- **test-reviewer**: Only if `*_test.go` files exist in the diff (test quality)
+Read `references/ai-antipatterns.md`. Check **every changed file** against all patterns listed.
 
-## Step 3: Parallel Agent Review
+**Priority patterns — must detect in every review:**
+- **#1** `gomock.Any()` for non-context parameters (no exceptions)
+- **#6** Direct model initialization instead of using `factory.NewFactory()` in tests
+- **#12** Fully-owned entity placed in `ReadonlyReference` instead of direct field
+- **#25** Private method defined in usecase interactor (receiver method)
+- **#31** Package-level private functions in domain/usecase/infrastructure layers
+- **#36** Direct domain model struct initialization in usecase (bypassing constructor)
+- **#37** Unnecessary nil/valid checks on guaranteed values
+- **#39** Field-by-field struct construction in conversion functions
+- **#40** Manual nil-pointer conversion when `.Ptr()` exists (use `null.String.Ptr()` etc.)
+- **#41** Redundant `var _ Interface = (*impl)(nil)` assertion
+- **#42** Ad-hoc per-test fixture helper instead of `factory.NewFactory()`
+- **#43** Conditional preload of fully-owned child entities
+- **#44** `pkg` layer importing `domain/errors` instead of using `fmt.Errorf`
+- **#45** `Set*` method that overwrites non-empty state (should be `Update` or specific verb)
+- **#46** Void mutator on a domain model (should return receiver `*Entity` or `(*Entity, error)`)
+- **#47** Usecase branching on raw domain model fields instead of calling a predicate
+- **#48** Precondition duplicated in usecase immediately before a model method that already checks it
 
-Launch all applicable agents in a **single message** using the Agent tool. All agents run with `run_in_background: true` for parallel execution.
+Record each finding: file path, line number, pattern violated, fix to apply.
 
-### CRITICAL: Use `subagent_type`, Do NOT Embed the Agent Definition
+## Step 4: Rule-Based Review
 
-Each agent is registered as a `subagent_type` via its frontmatter in `.claude/agents/{name}.md`. When you specify `subagent_type: "{name}"`, Claude Code automatically applies:
+Map each changed file to its rule category, then read `references/checklists.md` and apply relevant checklists.
 
-- The `model` field (e.g., `sonnet`) — prevents cost overruns from running on the parent's model
-- The `tools` allow-list (e.g., `[Read, Glob, Grep, Bash]`) — enforces read-only, preventing unintended edits
-- The agent's full body as its system prompt
-
-**Never** read the `.claude/agents/{name}.md` file and embed its contents in the `prompt`. Doing so:
-
-- Causes the agent to launch as `general-purpose` (all tools, including Edit/Write/Bash unrestricted) — breaks the read-only guarantee
-- Bypasses the `model: sonnet` declaration — may run on an expensive model
-- Duplicates the definition between the agent file and SKILL.md, causing drift
-
-### Prompt Content (review context only)
-
-The `prompt` argument should contain **only** the review context. The agent already has its role from the frontmatter/body.
-
-**Template**:
-```
-Target diff: HEAD vs {$BASE}
-
-Changed files:
-{changed_files}
-
-Follow your role definition exactly. Report findings in the format you define, including the Semantic Category field on every finding.
-```
-
-For **spec-reviewer**, also append:
-```
-Commit history:
-{git log output}
-```
-
-For **test-reviewer**, filter `{changed_files}` to `*_test.go` only.
-
-### Agent Tool Call Pattern
-
-Launch all applicable agents in one message:
-
-```
-Agent(
-  description: "Spec compliance review",
-  subagent_type: "spec-reviewer",
-  run_in_background: true,
-  prompt: "<review context only>"
-)
-Agent(
-  description: "Convention & rules review",
-  subagent_type: "convention-reviewer",
-  run_in_background: true,
-  prompt: "<review context only>"
-)
-Agent(
-  description: "Bug & anti-pattern review",
-  subagent_type: "bug-reviewer",
-  run_in_background: true,
-  prompt: "<review context only>"
-)
-Agent(
-  description: "Security & performance review",
-  subagent_type: "security-perf-reviewer",
-  run_in_background: true,
-  prompt: "<review context only>"
-)
-Agent(                                    # only if test files exist
-  description: "Test quality review",
-  subagent_type: "test-reviewer",
-  run_in_background: true,
-  prompt: "<review context only>"
-)
-```
-
-Wait for all agents to complete. You will be notified as each finishes.
-
-## Step 4: Aggregate Findings
-
-After all agents complete:
-
-1. **Collect** all findings from agent responses (each finding now carries `semantic_category`)
-2. **Deduplicate** by `(file, line, semantic_category)` — see dedup rationale below
-3. **Sort** by severity: `error` first, then `warning`, then `info`
-4. **Verify coverage** — ensure every changed file was reviewed by at least one agent
-5. **Separate** auto-fixable from manual-only findings
-
-### Dedup Rationale: Why `semantic_category`, Not `rule_id`
-
-Each agent defines its own rule_id prefix (`AP-*`, `SEC-*`, `CL-*`, etc.), so the same underlying issue can be reported under different rule_ids. Example: a missing `Preload: true` on a return-path `Get` could surface as `AP-21` (bug-reviewer), `PERF-...` (security-perf-reviewer, `query_preload_missing`), or `CL-repo-*` (convention-reviewer) — `rule_id`-based dedup would miss the overlap. `semantic_category` is defined by each agent in its own definition file; the orchestrator uses it as a single cross-agent dedup key.
-
-### Tie-breaking When Multiple Agents Flag the Same `semantic_category`
-
-When the dedup key collides, keep the finding with:
-1. **Highest severity** (`error` > `warning` > `info`)
-2. If tied, **most specific fix** (non-empty `Fix:` block wins over empty)
-3. If still tied, **convention-reviewer > security-perf-reviewer > bug-reviewer > test-reviewer > spec-reviewer** (preferred owner order)
-
-Note the winner's `rule_id` in the final report but merge all agents' notes into the finding's Description so no context is lost.
-
-### Finding Categories
-
-| Rule Prefix | Source Agent | Example |
-|---|---|---|
-| `SPEC-*` | spec-reviewer | SPEC-1 (missing requirement) |
-| `CL-*` | convention-reviewer | CL-usecase-3 (missing Validate), CL-migration-2, CL-proto-5 |
-| `AP-*` | bug-reviewer | AP-36 (direct struct init) |
-| `BUG-*` | bug-reviewer | BUG-1 (nil dereference) |
-| `SEC-*` | security-perf-reviewer | SEC-1 (missing authorization) |
-| `PERF-*` | security-perf-reviewer | PERF-1 (N+1 query) |
-| `TX-*` | security-perf-reviewer | TX-1 (ForUpdate missing) |
-| `TEST-*` | test-reviewer | TEST-1 (insufficient coverage) |
-
-### Agent Scope Matrix
-
-| Concern | Owner agent |
-|---------|------------|
-| Test files (`*_test.go`) | **test-reviewer** only — bug-reviewer skips tests |
-| TX boundary (RWTx, ForUpdate, nesting, long TX) | **security-perf-reviewer** only — bug-reviewer delegates |
-| IdP sync (StoreClaims, DeleteUser, order) | **security-perf-reviewer** only |
-| Input validation (`param.Validate()` missing) | **security-perf-reviewer** |
-| Migration safety | **convention-reviewer** |
-| Proto backward-compatibility | **convention-reviewer** |
-| Preload efficiency | security-perf-reviewer (`query_preload_unnecessary` / `query_preload_missing`) |
-| Logic bugs & non-TX anti-patterns | **bug-reviewer** |
+| File Pattern | Category |
+|---|---|
+| `internal/domain/model/**` | domain-model |
+| `internal/domain/service/**` | domain-service |
+| `internal/domain/errors/**` | domain-errors |
+| `internal/domain/repository/*.go` | repository-interface |
+| `internal/infrastructure/**/repository/**` | repository-impl |
+| `internal/infrastructure/**/marshaller/**` | marshaller |
+| `internal/usecase/**` (non-test) | usecase |
+| `internal/usecase/input/**` | input |
+| `internal/infrastructure/grpc/**/handler/**` | grpc-handler |
+| `internal/infrastructure/dependency/**` | dependency |
+| `schema/proto/**` | proto |
+| `db/**/migrations/**` | migration |
+| `**/*_test.go` | testing |
+| `*invitation*` | invitation-workflow |
+| `*authentication*`, `cognito/**`, `firebase/**` | external-service |
 
 ## Step 5: Auto-Fix Issues
 
-**Fix all auto-fixable issues immediately.** Edit files using available tools.
+**Fix all issues immediately—do not just report.** Edit files using available tools.
 
 Fix in this priority order:
-1. **Security** (SEC-*) — missing authorization, input validation gaps
-2. **Correctness** (BUG-*, AP-19, AP-20, AP-21) — ForUpdate, Preload, IdP sync
-3. **Convention** (CL-*) — method ordering, naming, pattern compliance
-4. **Anti-patterns** (AP-*) — gomock.Any(), direct field assignment
-5. **Test quality** (TEST-*, AP-1~6) — mock strictness, t.Parallel()
-6. **Performance** (PERF-*) — N+1, unnecessary queries
+1. **Correctness** – missing `ForUpdate`, IdP sync outside TX, wrong type for nullable fields
+2. **Rule violations** – method ordering, naming, missing required methods/fields
+3. **AI anti-patterns** – `gomock.Any()` misuse, direct field assignment, unnecessary abstractions
+4. **Test completeness** – missing test cases, wrong mock patterns, missing `t.Parallel()`
 
 When fixing test files that use `gomock.Any()` incorrectly, replace with exact expected values using domain model constructors.
 
-**SPEC-* findings are NOT auto-fixed** — they require human judgment on specification interpretation.
+## Step 6: Verify Fixes
 
-## Step 6: Verify Fixes (with Retry Loop)
+Always run after fixing:
 
-### 6a. Code Generation (if applicable)
+```bash
+/usr/bin/make lint.go
+```
 
-Run generation first — lint/test depend on generated code being up to date:
+Run if test files were changed or fixed:
+
+```bash
+/usr/bin/make test
+```
+
+Run code generation if applicable:
 
 ```bash
 # Migration files changed
@@ -212,72 +129,25 @@ Run generation first — lint/test depend on generated code being up to date:
 /usr/bin/make generate.mock
 ```
 
-### 6b. Lint + Test with Retry
-
-Run verification in a **bounded retry loop** (max 2 retries = 3 total attempts):
-
-```
-attempt = 1
-max_attempts = 3
-while attempt <= max_attempts:
-  run `/usr/bin/make lint.go`
-  if test files changed: run `/usr/bin/make test`
-  if all pass:
-    break
-  else:
-    parse failure output into synthetic findings:
-      - file / line extracted from error location
-      - rule_id = LINT-{n} or TEST-FAIL-{n}
-      - semantic_category = `lint_failure` or `test_failure`
-      - severity = error
-      - description = failure message
-    append to aggregated findings
-    return to Step 5 (Auto-Fix) scoped to only these new findings
-    attempt += 1
-```
-
-### 6c. Escalation After Exhaustion
-
-If attempt > max_attempts:
-- Do **not** discard the remaining failures
-- List each unresolved failure in Step 7's "Issues Requiring Manual Action"
-- Include the failure message verbatim and the file/line
-- Mark overall status as ⚠️ `N manual actions needed`
-
-### Anti-pattern: Silent Success
-
-Never report "✅ Ready" if lint or test failed and was not re-fixed. The verify-retry loop exists specifically so the reviewer cannot silently lie about verification.
-
 ## Step 7: Report
 
 ```markdown
 ## Diff Review Summary
 
 ### Scope
-- Base: origin/main (or master)
-- Changed files: N files
-- Agents launched: N
-
-### Agent Results
-| Agent | Files Reviewed | Findings | Auto-Fixed |
-|-------|---------------|----------|------------|
-| spec-reviewer | N | N (E:N W:N I:N) | 0 |
-| convention-reviewer | N | N (E:N W:N I:N) | N |
-| bug-reviewer | N | N (E:N W:N I:N) | N |
-| security-perf-reviewer | N | N (E:N W:N I:N) | N |
-| test-reviewer | N | N (E:N W:N I:N) | N |
-| **Total** | | **N** | **N** |
+- Base: origin/main
+- Changed files: N files across X categories
 
 ### Auto-Fixed Issues (N)
-1. **[Rule ID]** Short description
+1. **[Category]** Short description
    - `path/to/file.go:123`
    - Was: `<bad code>`
    - Fixed: `<good code>`
 
 ### Issues Requiring Manual Action (N)
-1. **[Rule ID]** Short description
+1. **[Category]** Short description
    - `path/to/file.go`
-   - Reason: Requires spec confirmation / `make generate.buf` needed
+   - Reason: Requires `make generate.buf` / `make generate.mock`
 
 ### Verification
 - [x] lint.go passes

--- a/.claude/skills/review-diff/references/ai-antipatterns.md
+++ b/.claude/skills/review-diff/references/ai-antipatterns.md
@@ -570,48 +570,40 @@ enum StaffRole {
 
 ## General AI Patterns (Across All Layers)
 
-### 31. Package-level private functions
+### 31. Package-level private functions in domain/usecase/infrastructure layers
 
-Package-level private functions (non-receiver functions) are prohibited in domain, usecase, and infrastructure layers. They pollute the package namespace and scatter logic.
+Package-level private (non-receiver) functions are prohibited in domain, usecase, and infrastructure layers. They scatter business logic and reduce testability.
 
 ```go
-// BAD - package-level private function
-func buildStaffQuery(id string) repository.GetStaffQuery {
-    return repository.GetStaffQuery{...}
-}
+// BAD - package-level private functions
+func buildStaffQuery(id string) repository.GetStaffQuery { ... }
+func toStaffModel(e *dbmodel.Staff) *model.Staff { ... }
+func validateStaffInput(param *input.AdminCreateStaff) error { ... }
 
-// BAD - package-level private helper
-func toStaffModel(param *input.AdminCreateStaff, t time.Time) *model.Staff {
-    return model.NewStaff(param.TenantID, param.Role, ...)
-}
+// GOOD (A) - inline short logic
+staff, err := i.repo.Get(ctx, repository.GetStaffQuery{
+    ID: null.StringFrom(id),
+    BaseGetOptions: repository.BaseGetOptions{OrFail: true},
+})
 
-// BAD - package-level validation helper
-func validateStaffInput(param *input.AdminCreateStaff) error {
-    if param.Email == "" {
-        return errors.RequestInvalidArgumentErr.New()
-    }
-    return nil
-}
-
-// GOOD - inline the logic
-staff, err := i.repo.Get(ctx, repository.GetStaffQuery{...})
-
-// GOOD - method on domain model
+// GOOD (B) - use domain model method for single entity logic
 func (m *Staff) Validate() error { ... }
 
-// GOOD - method on domain service struct
-func (s *staffService) Create(ctx context.Context, param StaffCreateParam) (*model.Staff, error) { ... }
+// GOOD (C) - use domain service struct method for multi-entity logic
+func (s *staffService) buildQuery(param StaffQueryParam) repository.GetStaffQuery { ... }
 ```
 
 **Decision guide:**
+
 | Situation | Solution |
 |---|---|
-| Short logic (few lines) | Inline in the calling method |
-| Reusable business logic | Method on domain model or domain service |
-| Data conversion | Method on marshaller struct, or inline |
-| Validation | Method on input struct or domain model |
+| Short logic (few lines) | Inline in the public method |
+| Logic spans multiple entities | Extract to `domain/service/` struct method |
+| Single entity behavior | Add method to `domain/model/` |
+| Repository query building | Inline (do not create helper) |
+| Conversion function (marshaller) | Inline or use struct receiver method |
 
-**Exception**: Package-level private functions are acceptable only when they are pure utility functions with no domain knowledge (e.g., generic type conversion helpers). Even then, prefer placing them in a shared `pkg/` utility package.
+**Exception**: Pure utility functions with no domain knowledge belong in `pkg/` packages (e.g., `pkg/id`, `pkg/email`).
 
 ---
 
@@ -662,144 +654,439 @@ Just implement the new behavior directly.
 
 ### 36. Direct domain model struct initialization in usecase (bypassing constructor)
 
+Domain model structs must be created using their constructor functions in the usecase layer, not direct struct initialization.
+
 ```go
-// BAD - direct struct literal in usecase
-func (i *adminStaffInteractor) Create(...) (*model.Staff, error) {
+// BAD - direct struct initialization bypasses constructor guarantees
+func (i *adminStaffInteractor) Create(ctx context.Context, param *input.AdminCreateStaff) (*model.Staff, error) {
     staff := &model.Staff{
         ID:          id.New(),
         TenantID:    param.TenantID,
         Role:        param.Role,
         DisplayName: param.DisplayName,
-        CreatedAt:   param.RequestTime,
-        UpdatedAt:   param.RequestTime,
+        // Missing fields risk silent bugs when new fields are added
     }
-    return staff, nil
+    // ...
 }
 
-// GOOD - use domain model constructor
-func (i *adminStaffInteractor) Create(...) (*model.Staff, error) {
-    staff := model.NewStaff(
-        param.TenantID,
-        param.Role,
-        param.AuthUID,
-        param.DisplayName,
-        param.ImagePath,
-        param.Email,
-        param.RequestTime,
-    )
-    return staff, nil
+// GOOD - use domain constructor
+func (i *adminStaffInteractor) Create(ctx context.Context, param *input.AdminCreateStaff) (*model.Staff, error) {
+    staff := model.NewStaff(param.TenantID, param.Role, param.AuthUID, param.DisplayName, param.ImagePath, param.Email, param.RequestTime)
+    // ...
 }
 ```
 
-**Why**: Constructors encapsulate initialization logic (ID generation, default values, field constraints). Bypassing them risks missing required fields and duplicates logic across call sites.
-
-**Note**: This is distinct from #7 (direct field assignment for updates). #7 is about mutation; this is about creation.
+**Why**: Constructors encapsulate ID generation (`id.New()`), default values, field constraints, and ensure all required fields are set. Direct initialization bypasses these guarantees and breaks silently when new fields are added to the model.
 
 ---
 
 ### 37. Unnecessary nil/valid checks on guaranteed values
 
+Do not add nil checks or `.Valid` checks on values that are guaranteed by preceding code.
+
 ```go
-// BAD - staff is guaranteed non-nil by OrFail: true
+// BAD - OrFail: true guarantees non-nil; nil check is impossible
 staff, err := i.staffRepository.Get(ctx, repository.GetStaffQuery{
-    ID:             null.StringFrom(param.StaffID),
+    ID: null.StringFrom(param.StaffID),
     BaseGetOptions: repository.BaseGetOptions{OrFail: true},
 })
 if err != nil {
     return nil, err
 }
-if staff == nil {  // Unnecessary - OrFail guarantees non-nil on success
+if staff == nil {  // IMPOSSIBLE - OrFail returns error if not found
     return nil, errors.StaffNotFoundErr.New()
 }
 
-// GOOD - trust OrFail guarantee
+// BAD - nullable.TypeFrom guarantees Valid == true
+role := nullable.TypeFrom(model.StaffRoleAdmin)
+if role.Valid {  // ALWAYS true
+    // ...
+}
+
+// GOOD - trust the guarantee
 staff, err := i.staffRepository.Get(ctx, repository.GetStaffQuery{
-    ID:             null.StringFrom(param.StaffID),
+    ID: null.StringFrom(param.StaffID),
     BaseGetOptions: repository.BaseGetOptions{OrFail: true},
 })
 if err != nil {
     return nil, err
 }
-// Use staff directly
-
-// BAD - checking .Valid on a value just set with TypeFrom
-role := nullable.TypeFrom(param.Role)
-if role.Valid {  // Always true
-    query.Role = role
-}
-
-// GOOD
-query.Role = nullable.TypeFrom(param.Role)
+// Use staff directly - guaranteed non-nil
 ```
 
-**Fix**: Remove nil/valid checks when the preceding code guarantees the value. Trust `OrFail`, `TypeFrom`, `StringFrom`, and similar constructors.
+**Why**: Unnecessary checks add noise, suggest distrust of established contracts, and mislead future readers about whether nil is actually possible.
 
 ---
 
 ### 38. Unnecessary intermediate variable declarations
 
+Do not assign to a variable if the value is immediately returned without modification.
+
 ```go
-// BAD - unnecessary variable
-result := someFunction(ctx, param)
-return result
-
-// GOOD
-return someFunction(ctx, param)
-
-// BAD - declaring then immediately returning
-staffs, err := i.staffRepository.List(ctx, query)
-if err != nil {
-    return nil, err
+// BAD - unnecessary intermediate variable
+func StaffToPb(m *model.Staff) *pb.Staff {
+    result := &pb.Staff{
+        Id:   m.ID,
+        Name: m.DisplayName,
+    }
+    return result
 }
-result := &output.AdminListStaffs{
-    Staffs:     staffs,
-    TotalCount: totalCount,
-}
-return result, nil
 
 // GOOD - return directly
-staffs, err := i.staffRepository.List(ctx, query)
-if err != nil {
-    return nil, err
+func StaffToPb(m *model.Staff) *pb.Staff {
+    return &pb.Staff{
+        Id:   m.ID,
+        Name: m.DisplayName,
+    }
 }
-return &output.AdminListStaffs{
-    Staffs:     staffs,
-    TotalCount: totalCount,
-}, nil
 ```
 
-**Exception**: Variables are acceptable when (1) the value is used multiple times, (2) conditional mutation is needed (e.g., nullable timestamp fields in marshallers), or (3) readability significantly improves.
+**Exceptions**: Intermediate variables are acceptable when:
+- The value is used more than once
+- Conditional mutation is needed before return (e.g., nullable timestamp prep)
+- Readability clearly benefits from a named variable
 
 ---
 
 ### 39. Field-by-field struct construction in conversion functions
 
+Conversion/marshaller functions must use struct literal initialization with all fields listed, not field-by-field assignment on an empty struct.
+
 ```go
-// BAD - empty struct then field-by-field assignment
-func StaffToPB(m *model.Staff) *pb.Staff {
-    result := &pb.Staff{}
-    result.Id = m.ID
-    result.DisplayName = m.DisplayName
-    result.Email = m.Email
-    result.Role = StaffRoleToPB(m.Role)
-    result.CreatedAt = timestamppb.New(m.CreatedAt)
-    result.UpdatedAt = timestamppb.New(m.UpdatedAt)
-    return result
+// BAD - field-by-field assignment on empty struct
+func ExampleToModel(e *dbmodel.Example) *model.Example {
+    m := &model.Example{}
+    m.ID = e.ID
+    m.TenantID = e.TenantID
+    m.Name = e.Name
+    m.Status = model.ExampleStatus(e.Status)
+    m.CreatedAt = e.CreatedAt
+    m.UpdatedAt = e.UpdatedAt
+    return m
 }
 
 // GOOD - struct literal with all fields
-func StaffToPB(m *model.Staff) *pb.Staff {
-    return &pb.Staff{
-        Id:          m.ID,
-        DisplayName: m.DisplayName,
-        Email:       m.Email,
-        Role:        StaffRoleToPB(m.Role),
-        CreatedAt:   timestamppb.New(m.CreatedAt),
-        UpdatedAt:   timestamppb.New(m.UpdatedAt),
+func ExampleToModel(e *dbmodel.Example) *model.Example {
+    return &model.Example{
+        ID:                e.ID,
+        TenantID:          e.TenantID,
+        Name:              e.Name,
+        Status:            model.ExampleStatus(e.Status),
+        CreatedAt:         e.CreatedAt,
+        UpdatedAt:         e.UpdatedAt,
+        ReadonlyReference: nil,
     }
 }
 ```
 
-**Why**: Field-by-field assignment makes it easy to miss fields silently. Struct literals cause compile errors when fields are added, catching omissions early.
+**Exception**: When conditional field assignment is required (e.g., `ReadonlyReference` populated only when `e.R != nil`, nullable timestamps), prepare variables first, then use a single struct literal with those variables.
 
-**Exception**: When conditional field assignment is needed (e.g., `ReadonlyReference` or nullable timestamps), use `m := &XXX{...}` with conditional blocks, then `return m`. But all non-conditional fields must still be in the initial struct literal.
+**Fix**: Replace with struct literal return. If `ReadonlyReference` needs conditional population, use the `var` + struct literal pattern from `repository.md`.
+
+---
+
+### 40. Manual nil-pointer conversion when `.Ptr()` exists
+
+For `null.String`, `null.Int64`, `null.Time` (from `github.com/aarondl/null/v8`), use `.Ptr()` directly instead of a manual `if .Valid` block.
+
+```go
+// BAD - manual block
+var paymentMethodID *string
+if m.PaymentMethodID.Valid {
+    paymentMethodID = &m.PaymentMethodID.String
+}
+result := &pb.Invoice{
+    PaymentMethodId: paymentMethodID,
+}
+
+// GOOD - inline .Ptr()
+result := &pb.Invoice{
+    PaymentMethodId: m.PaymentMethodID.Ptr(),
+}
+```
+
+**Why**: `null.String.Ptr()` returns `*string` (nil when `!Valid`). The manual block is dead weight and visually obscures the field mapping.
+
+**Fix**: Replace `var x *T; if .Valid { x = &.Field }` with `.Ptr()` inline in the struct literal.
+
+---
+
+### 41. Redundant `var _ Interface = (*impl)(nil)` assertion
+
+```go
+// BAD - redundant assertion, AI-generated boilerplate
+var _ StaffInvoiceInteractor = (*staffInvoiceInteractor)(nil)
+
+// GOOD - constructor return type already enforces the contract
+func NewStaffInvoiceInteractor(...) StaffInvoiceInteractor {
+    return &staffInvoiceInteractor{...}
+}
+```
+
+**Why**: When a constructor returns `InterfaceType`, the compiler already rejects any implementation that doesn't satisfy the interface. The `var _ Interface = (*impl)(nil)` is redundant and adds noise.
+
+**Fix**: Delete the assertion line entirely.
+
+---
+
+### 42. Ad-hoc per-test fixture helper instead of `factory.NewFactory()`
+
+```go
+// BAD - ad-hoc per-test helper duplicates factory responsibilities
+func newTestInvoice() *model.Invoice {
+    return &model.Invoice{
+        ID:             "test-invoice-id",
+        OrganizationID: "test-org-id",
+        Status:         model.InvoiceStatusDraft,
+        // ...
+    }
+}
+
+// In tests:
+invoice := newTestInvoice()
+
+// GOOD - use factory for deterministic, consistent test data
+testdata := factory.NewFactory()
+invoice := testdata.Invoice
+organizationID := invoice.OrganizationID
+```
+
+**Why**: `factory.NewFactory()` provides deterministic go-faker fixtures with consistent related entity references. Ad-hoc helpers diverge from factory data, cause inconsistency between tests, and duplicate responsibilities.
+
+**Fix**: Delete the helper function. Use `factory.NewFactory()` and access the entity via `testdata.Invoice` (or whichever entity field). If the factory doesn't have the entity yet, add it to `factory.go` following the existing pattern.
+
+---
+
+### 43. Conditional preload of fully-owned child entities
+
+```go
+// BAD - preloadStripe bool flag on owned children
+func (r *invoice) buildPreload(preloadStripe bool) []qm.QueryMod {
+    mods := []qm.QueryMod{
+        qm.Load(dbmodel.InvoiceRels.InvoiceItems),
+    }
+    if preloadStripe {
+        mods = append(mods, qm.Load(dbmodel.InvoiceRels.InvoiceStripe))
+    }
+    return mods
+}
+
+// GOOD - always load owned children unconditionally
+func (r *invoice) buildPreload() []qm.QueryMod {
+    return []qm.QueryMod{
+        qm.Load(dbmodel.InvoiceRels.InvoiceItems),
+        qm.Load(dbmodel.InvoiceRels.InvoiceStripe),
+        qm.Load(fmt.Sprintf("%s.%s", dbmodel.InvoiceRels.InvoiceItems, dbmodel.InvoiceItemRels.InvoiceItemStripe)),
+    }
+}
+```
+
+**Why**: Fully-owned 1:1/1:N children (entities that cannot exist without their parent, composed relationship) must always be loaded — they are part of the parent's aggregate. Optional `preload` flags are only appropriate for *reference* relations (e.g., `ReadonlyReference`). Conditional loading of owned children leads to incomplete domain models and nil-dereference bugs.
+
+---
+
+### 44. pkg layer importing domain layer
+
+```go
+// BAD - internal/pkg/phone/phone.go imports domain/errors
+import (
+    "github.com/abyssparanoia/rapid-go/internal/domain/errors"
+    "github.com/nyaruka/phonenumbers"
+)
+
+func ParseE164(rawNumber string, countryCode string) (*phonenumbers.PhoneNumber, error) {
+    num, err := phonenumbers.Parse(rawNumber, countryCode)
+    if err != nil {
+        return nil, errors.RequestInvalidArgumentErr.Wrap(err)  // domain dependency in pkg
+    }
+    ...
+}
+
+// GOOD - internal/pkg/phone/phone.go uses fmt.Errorf only
+import (
+    "fmt"
+    "github.com/nyaruka/phonenumbers"
+)
+
+func ParseE164(rawNumber string, countryCode string) (*phonenumbers.PhoneNumber, error) {
+    num, err := phonenumbers.Parse(rawNumber, countryCode)
+    if err != nil {
+        return nil, fmt.Errorf("invalid phone number format: %w", err)
+    }
+    ...
+}
+
+// Caller in handler/usecase wraps with domain error
+phoneNumber, err := phone.ParseE164(req.GetPhoneNumber(), "")
+if err != nil {
+    return nil, errors.RequestInvalidArgumentErr.Wrap(err)  // wrapping happens at call site
+}
+```
+
+**Why**: `internal/pkg` is a shared utility layer (logging, IDs, phone parsing, etc.) that must have no dependencies on `domain`, `usecase`, or `infrastructure`. It is used by all layers including domain itself. If `pkg` imported `domain/errors`, a circular import would result when domain tried to use pkg utilities. Domain error wrapping is the responsibility of the caller (handler or usecase layer), not the utility function.
+
+**Fix**: Remove the bool parameter. Always load all owned children in `buildPreload()`.
+
+---
+
+### 45. `Set*` method that overwrites non-empty state (should be `Update` or specific verb)
+
+`Set` is reserved for **fill-empty** semantics: the field was guaranteed empty before this call (nullable/derived field set for the first time). Using `Set` for an overwrite that replaces a possibly-meaningful existing value is misleading.
+
+```go
+// BAD - PaymentMethodID may already hold a value; calling this "Set" implies it was empty
+func (m *Invoice) SetPaymentMethodID(id string, t time.Time) {
+    m.PaymentMethodID = null.StringFrom(id)
+    m.UpdatedAt = t
+}
+
+// BAD - IsDefault is an existing bool being toggled; "Set" implies first-time assignment
+func (m *PaymentMethod) SetDefault(isDefault bool, t time.Time) {
+    m.IsDefault = isDefault
+    m.UpdatedAt = t
+}
+
+// GOOD - "Update" signals that an existing value is being replaced
+func (m *Invoice) UpdatePaymentMethodID(id string, t time.Time) *Invoice {
+    m.PaymentMethodID = null.StringFrom(id)
+    m.UpdatedAt = t
+    return m
+}
+
+func (m *PaymentMethod) UpdateIsDefault(isDefault bool, t time.Time) *PaymentMethod {
+    m.IsDefault = isDefault
+    m.UpdatedAt = t
+    return m
+}
+```
+
+**Rule of thumb**: if the field was guaranteed empty before the call → `Set`; if you are replacing a possibly-meaningful existing value → `Update`; if the change has business meaning or a state guard → use a specific verb (`Finalize`, `MarkPaid`, `Void`, `Delete`…).
+
+**Keep as `Set`**: `SetStripe` family (Invoice, InvoiceItem, InvoiceTax, Payment, Refund, Organization), `Staff.SetImageURL` — these genuinely fill a derived/nullable field that starts empty.
+
+**Fix**: Rename `Set{X}` → `Update{X}` (or a domain-specific verb) when the field may already hold a value. Update all call sites.
+
+---
+
+### 46. Void mutator on a domain model (should return receiver)
+
+All mutating methods on domain models must return the receiver (`*Entity`), and `(*Entity, error)` when they also validate a precondition. Void mutators (`func (m *Entity) Mutate(...)`) are forbidden.
+
+```go
+// BAD - void return; caller cannot chain and shape is inconsistent
+func (m *Invoice) ApplyTotals(subtotal int64, tax int64) {
+    m.Subtotal = subtotal
+    m.TaxAmount = tax
+    m.TotalAmount = subtotal + tax
+}
+
+func (m *Organization) Update(name null.String, t time.Time) {
+    if name.Valid { m.Name = name.String }
+    m.UpdatedAt = t
+}
+
+// GOOD - return receiver enables chaining and consistent shape
+func (m *Invoice) ApplyTotals(subtotal int64, tax int64) *Invoice {
+    m.Subtotal = subtotal
+    m.TaxAmount = tax
+    m.TotalAmount = subtotal + tax
+    return m
+}
+
+func (m *Organization) Update(name null.String, t time.Time) *Organization {
+    if name.Valid { m.Name = name.String }
+    m.UpdatedAt = t
+    return m
+}
+
+// When validating a precondition, return (*Entity, error)
+func (m *PaymentMethod) UpdateCreditCardDetails(...) (*PaymentMethod, error) {
+    if m.PaymentMethodType != PaymentMethodTypeCard {
+        return nil, errors.PaymentMethodTypeMismatchErr.New()
+    }
+    // mutate
+    return m, nil
+}
+```
+
+**Why**: Consistent return shape makes the codebase predictable, enables chaining, and distinguishes pure mutations from validated state transitions at a glance.
+
+**Fix**: Add `return m` (or `return m, nil`) to every void domain model mutator. Change signature from `void` to `*Entity` (or `(*Entity, error)` if validation is present). Update call sites if they were discarding an `error` return that is now a `(*Entity, error)`.
+
+---
+
+### 47. Usecase branching on raw domain model fields instead of calling a predicate
+
+Usecase and service code must not branch on a domain model's exported fields or status constants. Expose an intent-revealing predicate on the model and call it instead.
+
+```go
+// BAD - usecase inspects raw fields
+if inv.Status != model.InvoiceStatusDraft {
+    return nil, errors.InvoiceNotDraftErr.New()
+}
+
+// BAD - composite guard inline in usecase
+if !invoice.IsStripe() || !invoice.IsDownloadable() || !invoice.Stripe.Valid {
+    return "", errors.InvoiceHostedURLNotAvailableErr.New()
+}
+
+// BAD - idempotency check on raw fields in usecase
+if inv.PaymentMethodID.Valid && inv.PaymentMethodID.String == pm.ID {
+    return nil
+}
+
+// GOOD - intent-revealing predicates on the model
+if !inv.IsDraft() {
+    return nil, errors.InvoiceNotDraftErr.New()
+}
+
+if !invoice.IsHostedURLAvailable() {
+    return "", errors.InvoiceHostedURLNotAvailableErr.New()
+}
+
+if inv.HasPaymentMethod(pm.ID) {
+    return nil
+}
+```
+
+**Common predicates to add**: `IsDraft() bool`, `IsPending() bool`, `HasPaymentMethod(id string) bool`, `IsHostedURLAvailable() bool`, `IsStripe() bool`, `IsDownloadable() bool`.
+
+**Why**: Predicates encapsulate domain knowledge inside the model. If another caller forgets the guard, behavior diverges. Raw field inspection leaks domain semantics into the application layer and makes refactors error-prone.
+
+**Fix**: Add an intent-revealing predicate method to the domain model. Replace the inline field check in usecase with a call to the predicate.
+
+---
+
+### 48. Precondition duplicated in usecase immediately before a model method that already checks it
+
+If a model method validates a precondition internally and returns a domain error, the usecase must not check the same condition right before calling the method. Duplicating the guard risks the two checks diverging over time and misleads readers about where the authoritative check lives.
+
+```go
+// BAD - usecase duplicates Invoice.Finalize's internal Status != Draft guard
+invoice, err := i.invoiceRepository.Get(ctx, ...)
+if err != nil { return err }
+if invoice.Status != model.InvoiceStatusDraft {         // duplicate of Finalize's guard
+    return errors.InvoiceNotDraftErr.New()
+}
+invoice, err = invoice.Finalize(pm, t)                  // also checks Status == Draft
+if err != nil { return err }
+
+// GOOD - rely on the model method's own guard; delete the external duplicate
+invoice, err := i.invoiceRepository.Get(ctx, ...)
+if err != nil { return err }
+invoice, err = invoice.Finalize(pm, t)                  // single authoritative check
+if err != nil { return err }
+```
+
+**Exception — idempotency short-circuit**: A webhook handler that wants a silent `return nil` (not an error) on re-delivery may check a predicate *before* calling the model method, because the model method would return an error that the webhook cannot propagate. In this case, the predicate (e.g., `!inv.IsDraft()`) serves as an idempotency guard, not a duplicate validation:
+
+```go
+// OK - webhook idempotency short-circuit (silent nil, not an error)
+if !inv.IsDraft() {
+    logger.L(ctx).Info("invoice already finalized (idempotent)")
+    return nil  // silent return, not an error
+}
+inv, err = inv.Finalize(pm, t)  // model's own guard remains the safety net
+```
+
+**Fix**: Delete the usecase/service check. Let the model method's own guard produce the authoritative error. If a silent return is needed (webhook idempotency), keep the predicate call but document it as an idempotency guard, not a validation.

--- a/.claude/skills/review-diff/references/checklists.md
+++ b/.claude/skills/review-diff/references/checklists.md
@@ -2,13 +2,6 @@
 
 Detailed checklists for each file category. Apply the relevant sections based on changed files.
 
-## Domain Errors (`internal/domain/errors/**`)
-
-- [ ] Error codes are in ascending numerical order within `errors.go`
-- [ ] No duplicate error codes exist
-- [ ] New error codes use the next available sequence number in a new group (not reusing existing groups)
-- [ ] Error code groups are sorted by group number (E2001xx before E2002xx)
-
 ## Domain Model (`internal/domain/model/**`)
 
 - [ ] Entity has `ReadonlyReference` struct pointer for relations
@@ -57,14 +50,14 @@ Detailed checklists for each file category. Apply the relevant sections based on
 - [ ] All methods start with `param.Validate()` check
 - [ ] Write operations wrapped in `transactable.RWTx`
 - [ ] Get before update uses `ForUpdate: true` for locking
-- [ ] Entity creation uses domain constructors (`model.NewXxx()`), not direct struct init
 - [ ] State changes use domain methods (not direct field assignment)
-- [ ] No unnecessary nil/valid checks on values guaranteed by preceding code
-- [ ] No unnecessary intermediate variable declarations (return directly when possible)
+- [ ] Entity creation uses domain constructors (`model.NewXxx()`), not direct struct init
 - [ ] IdP sync (StoreClaims/DeleteUser) happens within transaction
 - [ ] On delete: IdP deletion before database deletion
 - [ ] Final return fetches entity with `Preload: true` for fresh data
 - [ ] Asset service called even if no assets currently exist
+- [ ] No unnecessary nil/valid checks on values guaranteed by preceding code
+- [ ] No unnecessary intermediate variable declarations (return directly when possible)
 - [ ] No package-level private functions (inline or move to struct method)
 
 ## Input Struct (`internal/usecase/input/**`)
@@ -138,16 +131,6 @@ Detailed checklists for each file category. Apply the relevant sections based on
 - [ ] `DeleteUser` called before database deletion
 - [ ] All IdP operations within transaction boundary
 
-## Architecture & File Placement (All new files)
-
-- [ ] Domain layer (`internal/domain/`) has NO infrastructure dependencies (no HTTP clients, no SDK imports, no DB packages)
-- [ ] Repository interfaces are in `internal/domain/repository/` — interfaces for external data access only (DB, external API)
-- [ ] Non-data-access interfaces (e.g., geocoding, IoT, publisher) belong in their own domain package (`internal/domain/{concept}/`) or in `internal/domain/service/`, NOT in `internal/domain/repository/`
-- [ ] Infrastructure implementations are in the correct subdirectory under `internal/infrastructure/` (e.g., `googlemaps/`, `cognito/`, `firebase/`)
-- [ ] DTO types for external API responses are in `internal/infrastructure/{provider}/internal/dto/`, NOT in the repository package itself
-- [ ] Marshaller files are under `internal/infrastructure/{db}/internal/marshaller/` — check that new marshallers don't introduce unnecessary type conversions when direct field mapping suffices
-- [ ] No new packages created under `internal/domain/` unless they represent a genuine domain concept — utility-style packages belong in `internal/pkg/`
-
 ## Invitation Workflow (`*invitation*`)
 
 - [ ] Status enum includes: Pending, Accepted, Rejected, Invalidated
@@ -155,3 +138,8 @@ Detailed checklists for each file category. Apply the relevant sections based on
 - [ ] State transition methods validate current state
 - [ ] `IsExpired()` helper method exists
 - [ ] Email sent within transaction
+
+## Pkg Utilities (`internal/pkg/**`)
+
+- [ ] No imports from `internal/domain`, `internal/usecase`, or `internal/infrastructure`
+- [ ] Errors returned as `fmt.Errorf` — domain error wrapping is the caller's responsibility


### PR DESCRIPTION
## Proposed Changes

- Pulled .claude/ content updates contributed by robohouse

## Implementation

Files synced from robohouse:

**Rules (updated):**
- `rules/domain-model.md` — `nullable.Type[T]` convention for optional owned 1:1 children, method naming conventions
- `rules/grpc-handler.md` — marshaller return patterns, `null.String`/`null.Int64` `.Ptr()` mapping rules
- `rules/proto-definition.md` — owned child message nesting rules, sort key enum positioning
- `rules/repository.md` — `IncludeDeleted` option, owned children unconditional preload rules
- `rules/usecase-interactor.md` — no raw field inspection, no private methods, unit testing requirements
- `rules/webhook-implementation.md` — `ForUpdate` + `IncludeDeleted` idempotency patterns
- `rules/worker-pattern.md` — import path formatting
- `rules/cli-command-pattern.md` — import path formatting
- `rules/repository.md` — import path formatting

**Rules (new):**
- `rules/specification.md` — specification document writing guidelines (mermaid diagrams, Japanese body)

**Skills (updated):**
- `skills/review-diff/SKILL.md` — enhanced review patterns
- `skills/review-diff/references/ai-antipatterns.md` — additional anti-pattern detection
- `skills/review-diff/references/checklists.md` — expanded checklists
- `skills/fix-review-comments/SKILL.md` — auto-commit and rule update features