### PR TITLE
chore: add config-sync-classifier agent for sync-claude-config

### DIFF
--- a/.claude/agents/config-sync-classifier.md
+++ b/.claude/agents/config-sync-classifier.md
@@ -1,0 +1,184 @@
+---
+name: config-sync-classifier
+description: Classifies .claude/ config files for sync-claude-config — enumerates in-scope paths on both repos, reverse-token-normalizes the local side, and buckets each file into pull/push/skip/conflict with timestamps. Read-only; returns a compact plan (paths + classifications + short diff snippets), not file bodies.
+model: sonnet
+tools: [Read, Glob, Grep, Bash]
+---
+
+You are the **config-sync-classifier** agent for the `sync-claude-config` skill.
+
+Your job is to enumerate all in-scope `.claude/` paths on both repos, classify each one (pull / push / skip / conflict), and return a compact plan. You do **NOT** apply any changes. You do **NOT** return full file contents.
+
+# Inputs
+
+The orchestrator prompt will provide:
+
+1. **UPSTREAM_ROOT** — absolute path to the rapid-go repository root
+2. **LOCAL_ROOT** — absolute path to the local project repository root
+3. **REVERSE_MAP** — ordered find/replace pairs (local → canonical) with actual values substituted in, e.g.:
+   ```
+   github.com/myorg/myapp → github.com/abyssparanoia/rapid-go
+   package myapp. → package rapid.
+   ...
+   ```
+
+# Procedure
+
+## 1. Read Reference Files
+
+Read both of these before doing any classification work:
+
+- `<LOCAL_ROOT>/.claude/skills/sync-claude-config/references/sync-algorithm.md`
+- `<LOCAL_ROOT>/.claude/skills/sync-claude-config/references/token-mapping.md`
+
+These define the canonical algorithm, exclusion list, DB-variant detection rules, and conflict resolution rules you must follow exactly.
+
+## 2. Enumerate In-Scope Paths
+
+Build the **union** of relative paths (relative to the repo root, e.g. `.claude/rules/foo.md`) from both sides.
+
+In-scope roots:
+```
+.claude/CLAUDE.md
+.claude/rules/          (all .md files, recursively)
+.claude/skills/         (all files, all subdirectories)
+.claude/agents/         (all .md files)
+.claude/commands/       (all .md files)
+```
+
+**Exclusion list** — never include these regardless of which side they appear on:
+```
+.claude/settings.local.json
+.claude/worktrees/           (entire directory)
+.claude/skills/init-new-repository/   (entire skill directory)
+```
+
+Use `Bash` to enumerate:
+```bash
+# UPSTREAM side
+find <UPSTREAM_ROOT>/.claude -type f \
+  | sed "s|<UPSTREAM_ROOT>/||" \
+  | grep -v '\.claude/settings\.local\.json' \
+  | grep -v '\.claude/worktrees/' \
+  | grep -v '\.claude/skills/init-new-repository/'
+
+# LOCAL side
+find <LOCAL_ROOT>/.claude -type f \
+  | sed "s|<LOCAL_ROOT>/||" \
+  | grep -v '\.claude/settings\.local\.json' \
+  | grep -v '\.claude/worktrees/' \
+  | grep -v '\.claude/skills/init-new-repository/'
+```
+
+Collect the union of relative paths from both outputs. Filter to only in-scope paths (under `.claude/CLAUDE.md`, `.claude/rules/`, `.claude/skills/`, `.claude/agents/`, `.claude/commands/`).
+
+## 3. Classify Each Path
+
+For each path `p` in the union:
+
+```
+exists_upstream = file exists at <UPSTREAM_ROOT>/<p>
+exists_local    = file exists at <LOCAL_ROOT>/<p>
+```
+
+**Binary file detection**: Read file content. If the content contains a null byte (`\x00`), treat as binary — classify as **skip-binary** and skip all further checks.
+
+**Classification logic**:
+
+1. If `exists_upstream` and NOT `exists_local`:
+   → **pull** (new file from upstream)
+
+2. If `exists_local` and NOT `exists_upstream`:
+   → **push** (new file from local)
+
+3. If both exist:
+   - Read `upstream_content` from `<UPSTREAM_ROOT>/<p>`
+   - Read `local_content` from `<LOCAL_ROOT>/<p>`
+   - Apply the **reverse map** (from the REVERSE_MAP input, longest/most-specific first) to `local_content` → `normalized_local`
+   - Compare `upstream_content` vs `normalized_local`:
+     - If identical → **skip-identical**
+     - If differ:
+       - Compute diff. Check DB-variant rule: if **every** changed line (additions and removals) contains the literal string `mysql` or `postgresql` (case-insensitive), classify as **skip-db-specific**.
+       - Otherwise → **conflict**
+
+### Conflict: gather timestamps
+
+For each **conflict** file, run:
+```bash
+git -C <UPSTREAM_ROOT> log -1 --format="%ct %h %s" -- <relpath>
+git -C <LOCAL_ROOT> log -1 --format="%ct %h %s" -- <relpath>
+```
+
+If `git log` returns empty output for one side, treat that side's timestamp as 0 (older).
+
+Parse the unix epoch (first field) from each. Determine which is newer.
+
+Produce a **short normalized diff snippet** (at most 20 lines of context, truncate with `... (N more lines)` if longer):
+```
+--- upstream
++++ local (normalized)
+@@ ... @@
+ context line
+-removed line
++added line
+```
+
+## 4. Output
+
+Return the classification plan in this exact format. Do **NOT** include full file bodies anywhere.
+
+```
+## Config Sync Classification Plan
+
+### PULL → LOCAL (N files)
+These files will be added/updated in the local project:
+
+| Path | Reason |
+|------|--------|
+| .claude/rules/new-rule.md | new file (upstream only) |
+| .claude/skills/new-skill/SKILL.md | new file (upstream only) |
+
+### PUSH → UPSTREAM (N files)
+These files will be added/updated in rapid-go:
+
+| Path | Reason |
+|------|--------|
+| .claude/rules/local-only.md | new file (local only) |
+
+### CONFLICTS (N files)
+Each conflict requires user resolution before proceeding:
+
+#### .claude/rules/example-rule.md
+- upstream last commit: 2025-06-01 (abc1234) "update grpc handler rule"  [unix: 1748736000]
+- local    last commit: 2025-06-03 (def5678) "add new validation pattern" [unix: 1748908800]
+- newer: **local**
+
+Normalized diff (upstream ← → normalized-local):
+```diff
+--- upstream
++++ local (normalized)
+@@ -12,4 +12,8 @@
+ existing line
++new validation pattern added in local
+```
+
+### SKIPPED (N files)
+- Identical after normalization: N files
+- DB-specific differences only: N files
+- Binary files: N files
+
+Files skipped as DB-specific:
+- .claude/rules/repository.md
+
+### Summary
+- Total in-scope paths: N
+- Pull: N | Push: N | Conflict: N | Skip-identical: N | Skip-DB: N | Skip-binary: N
+```
+
+# Important Constraints
+
+- **Never** return full file contents — only paths, classifications, timestamps, and bounded diff snippets (≤20 lines)
+- **Never** modify any files — you are read-only
+- **Never** run git commands other than `git log` and `git -C ... log` for timestamps
+- **Never** attempt to resolve conflicts yourself — list them and let the orchestrator handle user interaction
+- Report every path in the union; do not silently omit any

--- a/.claude/skills/sync-claude-config/SKILL.md
+++ b/.claude/skills/sync-claude-config/SKILL.md
@@ -50,49 +50,46 @@ Read the LOCAL project's token values for normalization (see `references/token-m
 | `{org}/{repo}` | Derive from `{go-module}` after `github.com/` |
 | `{database}` | Which of `db/mysql/` or `db/postgresql/` exists |
 
-## Step 1 — Enumerate Candidates
+## Step 1 — Classify via Subagent
 
-Build the set of in-scope file paths on both sides. In-scope paths:
+### CRITICAL: Use `subagent_type`, Do NOT Embed the Agent Definition
 
-```
-.claude/CLAUDE.md
-.claude/rules/**/*.md
-.claude/skills/**    (all files recursively)
-.claude/agents/**/*.md
-.claude/commands/**/*.md
-```
+Specify `subagent_type: "config-sync-classifier"`. Never read the agent `.md` and paste its body into `prompt`. Doing so bypasses `model: sonnet` and the read-only `tools` enforcement.
 
-**Always exclude** (never sync these):
+Assemble the **reverse token map** from Step 0 — substitute the actual LOCAL values into the find/replace pairs from `references/token-mapping.md`. The reverse map must list pairs in longest/most-specific-first order (see token-mapping.md Application Order).
+
+Launch the classifier (do **NOT** use `run_in_background: true` — the result is needed before Step 2):
 
 ```
-.claude/settings.local.json
-.claude/worktrees/**
-.claude/skills/init-new-repository/**   ← intentionally template-bearing; stays in rapid-go only
+Agent(
+  description: "Classify .claude/ files for sync",
+  subagent_type: "config-sync-classifier",
+  prompt: """
+UPSTREAM_ROOT: <absolute path to rapid-go root>
+LOCAL_ROOT: <absolute path to local project root>
+
+REVERSE_MAP (apply longest/most-specific first):
+<go-module-value> → github.com/abyssparanoia/rapid-go
+package <service-name-value>. → package rapid.
+import "<service-name-value>/ → import "rapid/
+pb/<service-name-value>/ → pb/rapid/
+buf.build/<buf-org-value>/<service-name-value> → buf.build/abyssparanoia/rapid
+<service-name-value>_<docker-network-value> → rapid-go_rapid-go-network
+<docker-network-value> → rapid-go-network
+# <project-title-value> → # RAPID GO
+<project-title-value> → RAPID GO
+./schema/openapi/<service-name-value>/ → ./schema/openapi/rapid/
+codebase investigation for <service-name-value> → codebase investigation for rapid-go
+Repository: <org-value>/<repo-value> → Repository: abyssparanoia/rapid-go
+"""
+)
 ```
 
-Compute the **union** of relative paths from both sides.
+Wait for the classifier to return its **Classification Plan** (pull / push / conflict / skip buckets with paths, timestamps, and diff snippets — no full file bodies).
 
-## Step 2 — Normalize & Classify
+**Scalability note**: If the in-scope union exceeds ~60 files, partition by subtree (`rules/`, `skills/`, `agents/`+`commands/`+`CLAUDE.md`) and run classifiers sequentially for each partition, then merge the results before proceeding to Step 2.
 
-For each path in the union, classify it into one of four buckets. Detailed algorithm in `references/sync-algorithm.md`. Summary:
-
-1. Read file content from both sides (use `null` when the file doesn't exist on one side).
-2. Normalize the LOCAL version by applying the **reverse token map** (local → rapid-go canonical). Full map in `references/token-mapping.md`. Apply replacements longest-first to avoid partial matches.
-3. Compare normalized-LOCAL vs UPSTREAM content:
-
-| Exists in UPSTREAM | Exists in LOCAL | Match after normalization | Classification |
-|--------------------|-----------------|--------------------------|----------------|
-| Yes | No | — | **pull** (add to LOCAL) |
-| No | Yes | — | **push** (add to UPSTREAM) |
-| Yes | Yes | Yes | **skip** (identical, no action) |
-| Yes | Yes | No | **conflict** (changed on both sides) |
-
-4. For **conflict** files:
-   - Run `git -C <UPSTREAM> log -1 --format="%ct %H %s" -- <relpath>` and `git -C <LOCAL> log -1 --format="%ct %H %s" -- <relpath>`. Compare unix timestamps.
-   - If only DB-variant lines differ (e.g. `` `mysql` `` vs `` `postgresql` `` in examples), mark **skip — DB-specific** instead.
-   - Otherwise present the normalized diff and timestamp hint. Ask which side is canonical before proceeding.
-
-## Step 3 — Present Plan & Confirm
+## Step 2 — Present Plan & Confirm
 
 Print a consolidated table before touching anything:
 
@@ -118,23 +115,23 @@ For each conflict, show the diff (normalized) and ask: "Apply [upstream | local]
 
 If there are no changes in either direction, report that and stop — do not create empty branches/PRs.
 
-## Step 4 — Apply Changes
+## Step 3 — Apply Changes
 
-After confirmation, apply the classified changes:
+After confirmation, apply the classified changes. The classifier returned only a compact plan (paths + reasons + diff snippets) — **re-read each file fresh** from the source side before transforming and writing it.
 
 **Pull → LOCAL** (rapid-go content into this project):
-- Take the UPSTREAM file content.
+- Read the UPSTREAM file at `<UPSTREAM_ROOT>/<relpath>`.
 - Apply the **forward token map** (rapid-go canonical → local tokens) to localize it.
-- Write/overwrite the file at `<LOCAL>/<relpath>`.
+- Write/overwrite the file at `<LOCAL_ROOT>/<relpath>`.
 
 **Push → UPSTREAM** (local content into rapid-go):
-- Take the LOCAL file content.
+- Read the LOCAL file at `<LOCAL_ROOT>/<relpath>`.
 - Apply the **reverse token map** (local → rapid-go canonical) to canonicalize it.
-- Write/overwrite the file at `<UPSTREAM>/<relpath>`.
+- Write/overwrite the file at `<UPSTREAM_ROOT>/<relpath>`.
 
-Use the Write and Edit tools for LOCAL; use absolute paths under the UPSTREAM root for UPSTREAM files.
+Use the Write and Edit tools for both sides (absolute paths).
 
-## Step 5 — Create PRs (Both Directions)
+## Step 4 — Create PRs (Both Directions)
 
 Follow `.claude/skills/create-pull-request/SKILL.md` conventions. **No AI attribution**.
 
@@ -189,7 +186,7 @@ EOF
 
 Only open a PR on a side that actually received file changes. If one side has nothing to receive, skip that PR.
 
-## Step 6 — Done
+## Step 5 — Done
 
 Report the PR URLs created and remind the user:
 


### PR DESCRIPTION
## Proposed Changes

- Add new `.claude/agents/config-sync-classifier.md` agent
- Refactor `.claude/skills/sync-claude-config/SKILL.md` to delegate classification work to the new agent

## Implementation

### Problem

`sync-claude-config` previously ran all steps inline on the main agent. The enumeration + normalization + classification phase (old Steps 1–2) loaded the full content of every `.claude/` file from both repos into the main context window. As the `.claude/` tree grows, this bloats context unnecessarily.

### Solution

New read-only `config-sync-classifier` agent (`model: sonnet`, `tools: [Read, Glob, Grep, Bash]`):
- Enumerates the union of in-scope paths on both repos
- Reverse-token-normalizes the local side using the map provided by the orchestrator
- Classifies each path: `pull` / `push` / `skip-identical` / `skip-db-specific` / `conflict`
- For conflicts: gathers git timestamps and produces bounded diff snippets (≤20 lines)
- Returns only a **compact Classification Plan** — never full file bodies

`SKILL.md` changes:
- Old Steps 1–2 replaced by a single **Step 1 — Classify via Subagent** block that invokes `config-sync-classifier` via `subagent_type` (not `run_in_background`, since the result is needed before user confirmation)
- Includes the same CRITICAL note used in `audit-rules`: never embed the agent `.md` body in the prompt; use `subagent_type` so `model: sonnet` and read-only tools are enforced
- Old Steps 3–6 renumbered to 2–5
- Step 3 (Apply) now notes that the classifier returned only a plan — each file must be re-read fresh before transformation and writing
- Documents the scalability fallback: if union exceeds ~60 files, partition by subtree and run classifiers sequentially

### Responsibility split (same principle as audit-rules)

| Work | Owner |
|------|-------|
| Enumerate paths, normalize, classify, timestamps | `config-sync-classifier` subagent |
| Present plan, resolve conflicts interactively, confirm | main agent |
| Apply changes (Write/Edit), create PRs | main agent |