### PR TITLE
chore: fix rule-compliance violations (audit-rules)

### DIFF
--- a/db/mysql/migrations/1_initialize.sql
+++ b/db/mysql/migrations/1_initialize.sql
@@ -101,13 +101,13 @@ CREATE TABLE `staffs` (
 COMMENT "staff";
 
 -- +goose Down
-DROP TABLE staffs;
-DROP TABLE staff_roles;
-DROP TABLE tenant_tags;
-DROP TABLE tenant_tag_types;
-DROP TABLE tenants;
-DROP TABLE admins;
-DROP TABLE admin_roles;
-DROP TABLE assets;
-DROP TABLE asset_types;
-DROP TABLE content_types;
+DROP TABLE IF EXISTS staffs;
+DROP TABLE IF EXISTS staff_roles;
+DROP TABLE IF EXISTS tenant_tags;
+DROP TABLE IF EXISTS tenant_tag_types;
+DROP TABLE IF EXISTS tenants;
+DROP TABLE IF EXISTS admins;
+DROP TABLE IF EXISTS admin_roles;
+DROP TABLE IF EXISTS assets;
+DROP TABLE IF EXISTS asset_types;
+DROP TABLE IF EXISTS content_types;

--- a/db/spanner/migrations/00002_staff.sql
+++ b/db/spanner/migrations/00002_staff.sql
@@ -7,7 +7,7 @@ CREATE TABLE `Staffs` (
   `TenantID`                 STRING(36)     NOT NULL, -- tenant id
   `Role`                     STRING(32)     NOT NULL, -- role
   `AuthUID`                  STRING(256)    NOT NULL, -- auth uid
-  `DisplayName`              STRING(256)    NOT NULL, -- role
+  `DisplayName`              STRING(256)    NOT NULL, -- display name
   `ImagePath`                STRING(MAX)    NOT NULL, -- image path
   `Email`                    STRING(512)    NOT NULL, -- email
   `CreatedAt`                TIMESTAMP      NOT NULL, -- creation date

--- a/internal/domain/errors/public_metadata_test.go
+++ b/internal/domain/errors/public_metadata_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestWithPublicMetadata_SingleEntry(t *testing.T) {
+	t.Parallel()
 	err := goerr.New("test error")
 	err = WithPublicMetadata(err, "field", "email")
 
@@ -20,6 +21,7 @@ func TestWithPublicMetadata_SingleEntry(t *testing.T) {
 }
 
 func TestWithPublicMetadata_MultipleCallsMerge(t *testing.T) {
+	t.Parallel()
 	err := goerr.New("test error")
 	err = WithPublicMetadata(err, "field", "email")
 	err = WithPublicMetadata(err, "form_id", "signup")
@@ -32,6 +34,7 @@ func TestWithPublicMetadata_MultipleCallsMerge(t *testing.T) {
 }
 
 func TestWithPublicMetadata_OverwritesSameKey(t *testing.T) {
+	t.Parallel()
 	err := goerr.New("test error")
 	err = WithPublicMetadata(err, "field", "original")
 	err = WithPublicMetadata(err, "field", "overwritten")
@@ -43,6 +46,7 @@ func TestWithPublicMetadata_OverwritesSameKey(t *testing.T) {
 }
 
 func TestWithPublicMetadata_IntValue(t *testing.T) {
+	t.Parallel()
 	err := goerr.New("test error")
 	err = WithPublicMetadata(err, "count", 42)
 
@@ -52,6 +56,7 @@ func TestWithPublicMetadata_IntValue(t *testing.T) {
 }
 
 func TestWithPublicMetadata_BoolValue(t *testing.T) {
+	t.Parallel()
 	err := goerr.New("test error")
 	err = WithPublicMetadata(err, "is_expired", true)
 
@@ -61,6 +66,7 @@ func TestWithPublicMetadata_BoolValue(t *testing.T) {
 }
 
 func TestWithPublicMetadata_SliceValue(t *testing.T) {
+	t.Parallel()
 	err := goerr.New("test error")
 	tags := []string{"a", "b"}
 	err = WithPublicMetadata(err, "tags", tags)
@@ -71,6 +77,7 @@ func TestWithPublicMetadata_SliceValue(t *testing.T) {
 }
 
 func TestWithPublicMetadata_NestedMapValue(t *testing.T) {
+	t.Parallel()
 	err := goerr.New("test error")
 	nested := map[string]any{"k": "v", "n": 1}
 	err = WithPublicMetadata(err, "details", nested)
@@ -81,22 +88,26 @@ func TestWithPublicMetadata_NestedMapValue(t *testing.T) {
 }
 
 func TestPublicMetadata_NilError(t *testing.T) {
+	t.Parallel()
 	meta := PublicMetadata(nil)
 	assert.Nil(t, meta)
 }
 
 func TestPublicMetadata_NonGoerr(t *testing.T) {
+	t.Parallel()
 	meta := PublicMetadata(fmt.Errorf("plain error"))
 	assert.Nil(t, meta)
 }
 
 func TestPublicMetadata_NoMetadataSet(t *testing.T) {
+	t.Parallel()
 	err := goerr.New("test error")
 	meta := PublicMetadata(err)
 	assert.Nil(t, meta)
 }
 
 func TestPublicMetadata_ThroughWrapChain(t *testing.T) {
+	t.Parallel()
 	inner := goerr.New("inner error")
 	inner = WithPublicMetadata(inner, "field", "email")
 
@@ -112,6 +123,7 @@ func TestPublicMetadata_ThroughWrapChain(t *testing.T) {
 }
 
 func TestWithPublicMetadata_DoesNotLeakToOtherValues(t *testing.T) {
+	t.Parallel()
 	err := goerr.New("test error")
 	err = err.WithValue("sensitive_key", "sensitive_value")
 	err = WithPublicMetadata(err, "public_key", "public_value")

--- a/internal/domain/model/admin.go
+++ b/internal/domain/model/admin.go
@@ -40,12 +40,13 @@ func NewAdmin(
 func (m *Admin) Update(
 	displayName null.String,
 	t time.Time,
-) {
+) *Admin {
 	if displayName.Valid {
 		m.DisplayName = displayName.String
 	}
 
 	m.UpdatedAt = t
+	return m
 }
 
 func (m *Admin) UpdateRole(role AdminRole, t time.Time) *Admin {

--- a/internal/domain/model/staff.go
+++ b/internal/domain/model/staff.go
@@ -60,8 +60,9 @@ func (m *Staff) Exist() bool {
 
 func (m *Staff) SetImageURL(
 	imageURL string,
-) {
+) *Staff {
 	m.ImageURL = null.StringFrom(imageURL)
+	return m
 }
 
 func (m *Staff) Update(
@@ -69,7 +70,7 @@ func (m *Staff) Update(
 	role nullable.Type[StaffRole],
 	imagePath null.String,
 	t time.Time,
-) {
+) *Staff {
 	if displayName.Valid {
 		m.DisplayName = displayName.String
 	}
@@ -80,4 +81,13 @@ func (m *Staff) Update(
 		m.ImagePath = imagePath.String
 	}
 	m.UpdatedAt = t
+	return m
+}
+
+func (es Staffs) IDs() []string {
+	ids := make([]string, 0, len(es))
+	for _, e := range es {
+		ids = append(ids, e.ID)
+	}
+	return ids
 }

--- a/internal/domain/model/staff_role.go
+++ b/internal/domain/model/staff_role.go
@@ -26,6 +26,10 @@ func (m StaffRole) IsAdmin() bool {
 	return m == StaffRoleAdmin
 }
 
+func (m StaffRole) IsNormal() bool {
+	return m == StaffRoleNormal
+}
+
 func (m StaffRole) Valid() bool {
 	return m != StaffRoleUnknown && m != ""
 }

--- a/internal/domain/model/tenant.go
+++ b/internal/domain/model/tenant.go
@@ -54,10 +54,19 @@ func NewTenantTag(
 func (m *Tenant) Update(
 	name null.String,
 	t time.Time,
-) {
+) *Tenant {
 	if name.Valid {
 		m.Name = name.String
 	}
 
 	m.UpdatedAt = t
+	return m
+}
+
+func (es Tenants) IDs() []string {
+	ids := make([]string, 0, len(es))
+	for _, e := range es {
+		ids = append(ids, e.ID)
+	}
+	return ids
 }

--- a/internal/domain/repository/admin_authentication.go
+++ b/internal/domain/repository/admin_authentication.go
@@ -7,7 +7,7 @@ import (
 	"github.com/abyssparanoia/rapid-go/internal/domain/model"
 )
 
-//go:generate go run go.uber.org/mock/mockgen -source=$GOFILE -destination=mock/$GOFILE -package=mock_repository
+//go:generate go tool go.uber.org/mock/mockgen -source=$GOFILE -destination=mock/$GOFILE -package=mock_repository
 type AdminAuthentication interface {
 	VerifyIDToken(ctx context.Context, idToken string) (*model.AdminClaims, error)
 	GetUserByEmail(ctx context.Context, email string) (*AdminAuthenticationGetUserByEmailResult, error)

--- a/internal/domain/repository/tenant.go
+++ b/internal/domain/repository/tenant.go
@@ -45,8 +45,8 @@ type Tenant interface {
 }
 
 type GetTenantQuery struct {
-	ID null.String
 	BaseGetOptions
+	ID null.String
 }
 
 type ListTenantsQuery struct {

--- a/internal/domain/service/asset_impl.go
+++ b/internal/domain/service/asset_impl.go
@@ -85,15 +85,17 @@ func (s *assetService) BatchSetStaffURLs(
 	requestTime time.Time,
 ) error {
 	for _, staff := range staffs {
-		imageURL, err := s.assetRepository.GenerateReadURL(
-			ctx,
-			staff.ImagePath,
-			requestTime,
-		)
-		if err != nil {
-			return err
+		if staff.ImagePath != "" {
+			imageURL, err := s.assetRepository.GenerateReadURL(
+				ctx,
+				staff.ImagePath,
+				requestTime,
+			)
+			if err != nil {
+				return err
+			}
+			staff.SetImageURL(imageURL)
 		}
-		staff.SetImageURL(imageURL)
 
 		if staff.ReadonlyReference != nil && staff.ReadonlyReference.Tenant != nil {
 			if err := s.BatchSetTenantURLs(ctx, model.Tenants{staff.ReadonlyReference.Tenant}, requestTime); err != nil {

--- a/internal/infrastructure/cmd/internal/schema_migration_cmd/database_cmd/cmd.go
+++ b/internal/infrastructure/cmd/internal/schema_migration_cmd/database_cmd/cmd.go
@@ -16,11 +16,10 @@ func NewDatabaseCmd() *cobra.Command {
 			}
 		},
 	}
-	cmd.AddCommand(&cobra.Command{
+	createCmd := &cobra.Command{
 		Use:   "create",
 		Short: "create new migration file",
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Flags().StringP("name", "n", "", "file name")
 			name, err := cmd.Flags().GetString("name")
 			if err != nil {
 				panic(err)
@@ -30,7 +29,9 @@ func NewDatabaseCmd() *cobra.Command {
 			}
 			migration.RunNewFile(name)
 		},
-	})
+	}
+	createCmd.Flags().StringP("name", "n", "", "file name")
+	cmd.AddCommand(createCmd)
 	cmd.AddCommand(&cobra.Command{
 		Use:   "up",
 		Short: "migrate up",

--- a/internal/infrastructure/dependency/dependency.go
+++ b/internal/infrastructure/dependency/dependency.go
@@ -125,10 +125,7 @@ func (d *Dependency) Inject(
 		assetService,
 	)
 	d.StaffStaffInteractor = usecase.NewStaffStaffInteractor(
-		transactable,
-		tenantRepository,
 		staffRepository,
-		staffService,
 		assetService,
 	)
 	d.StaffAssetInteractor = usecase.NewStaffAssetInteractor(

--- a/internal/infrastructure/dependency/dependency_gcp.go
+++ b/internal/infrastructure/dependency/dependency_gcp.go
@@ -123,10 +123,7 @@ func (d *Dependency) Inject(
 		assetService,
 	)
 	d.StaffStaffInteractor = usecase.NewStaffStaffInteractor(
-		transactable,
-		tenantRepository,
 		staffRepository,
-		staffService,
 		assetService,
 	)
 	d.StaffAssetInteractor = usecase.NewStaffAssetInteractor(

--- a/internal/infrastructure/firebase/repository/staff_authentication.go
+++ b/internal/infrastructure/firebase/repository/staff_authentication.go
@@ -17,7 +17,7 @@ import (
 	"github.com/abyssparanoia/rapid-go/internal/infrastructure/firebase/internal/marshaller"
 )
 
-type staffStaffAuthentication struct {
+type staffAuthentication struct {
 	cli          *auth.Client
 	clientAPIKey string
 	emulatorHost string
@@ -28,14 +28,14 @@ func NewStaffAuthentication(
 	firebaseClientAPIKey string,
 	emulatorHost string,
 ) repository.StaffAuthentication {
-	return &staffStaffAuthentication{
+	return &staffAuthentication{
 		cli:          firebaseAuthCli,
 		clientAPIKey: firebaseClientAPIKey,
 		emulatorHost: emulatorHost,
 	}
 }
 
-func (r *staffStaffAuthentication) VerifyIDToken(
+func (r *staffAuthentication) VerifyIDToken(
 	ctx context.Context,
 	idToken string,
 ) (*model.StaffClaims, error) {
@@ -51,7 +51,7 @@ func (r *staffStaffAuthentication) VerifyIDToken(
 	return marshaller.StaffClaimsToModel(t.UID, email, t.Claims), nil
 }
 
-func (r *staffStaffAuthentication) GetUserByEmail(
+func (r *staffAuthentication) GetUserByEmail(
 	ctx context.Context,
 	email string,
 ) (*repository.StaffAuthenticationGetUserByEmailResult, error) {
@@ -71,7 +71,7 @@ func (r *staffStaffAuthentication) GetUserByEmail(
 	}, nil
 }
 
-func (r *staffStaffAuthentication) CreateUser(
+func (r *staffAuthentication) CreateUser(
 	ctx context.Context,
 	param repository.StaffAuthenticationCreateUserParam,
 ) (string, error) {
@@ -87,7 +87,7 @@ func (r *staffStaffAuthentication) CreateUser(
 	return res.UID, nil
 }
 
-func (r *staffStaffAuthentication) StoreClaims(
+func (r *staffAuthentication) StoreClaims(
 	ctx context.Context,
 	authUID string,
 	claims *model.StaffClaims,
@@ -98,7 +98,7 @@ func (r *staffStaffAuthentication) StoreClaims(
 	return nil
 }
 
-func (r *staffStaffAuthentication) CreateCustomToken(
+func (r *staffAuthentication) CreateCustomToken(
 	ctx context.Context,
 	authUID string,
 ) (string, error) {
@@ -109,7 +109,7 @@ func (r *staffStaffAuthentication) CreateCustomToken(
 	return customToken, nil
 }
 
-func (r *staffStaffAuthentication) CreateIDToken(
+func (r *staffAuthentication) CreateIDToken(
 	ctx context.Context,
 	email string,
 	password string,

--- a/internal/infrastructure/gcs/repository/asset.go
+++ b/internal/infrastructure/gcs/repository/asset.go
@@ -11,6 +11,7 @@ import (
 	"github.com/abyssparanoia/rapid-go/internal/domain/errors"
 	"github.com/abyssparanoia/rapid-go/internal/domain/model"
 	"github.com/abyssparanoia/rapid-go/internal/domain/repository"
+	"github.com/abyssparanoia/rapid-go/internal/pkg/now"
 )
 
 const (
@@ -67,7 +68,7 @@ func (r *asset) GenerateWritePresignedURL(
 	}
 
 	opts := &storage.SignedURLOptions{
-		Expires:     time.Now().Add(expires),
+		Expires:     now.Now().Add(expires),
 		Method:      http.MethodPut,
 		ContentType: contentType.String(),
 	}

--- a/internal/infrastructure/grpc/internal/handler/admin/tenant.go
+++ b/internal/infrastructure/grpc/internal/handler/admin/tenant.go
@@ -90,6 +90,7 @@ func (h *AdminHandler) DeleteTenant(ctx context.Context, req *admin_apiv1.Delete
 		ctx,
 		input.NewAdminDeleteTenant(
 			req.GetTenantId(),
+			request_interceptor.GetRequestTime(ctx),
 		),
 	)
 	if err != nil {

--- a/internal/infrastructure/grpc/internal/handler/debug/handler.go
+++ b/internal/infrastructure/grpc/internal/handler/debug/handler.go
@@ -1,8 +1,6 @@
 package debug
 
 import (
-	"context"
-
 	debug_apiv1 "github.com/abyssparanoia/rapid-go/internal/infrastructure/grpc/pb/rapid/debug_api/v1"
 	"github.com/abyssparanoia/rapid-go/internal/usecase"
 )
@@ -17,37 +15,4 @@ func NewDebugHandler(
 	return &DebugHandler{
 		debugInteractor: debugInteractor,
 	}
-}
-
-func (h *DebugHandler) CreateAdminIDToken(ctx context.Context, req *debug_apiv1.CreateAdminIDTokenRequest) (*debug_apiv1.CreateAdminIDTokenResponse, error) {
-	idToken, err := h.debugInteractor.CreateAdminIDToken(ctx, req.GetEmail(), req.GetPassword())
-	if err != nil {
-		return nil, err
-	}
-	return &debug_apiv1.CreateAdminIDTokenResponse{
-		IdToken: idToken,
-	}, nil
-}
-
-func (h *DebugHandler) CreateStaffIDToken(ctx context.Context, req *debug_apiv1.CreateStaffIDTokenRequest) (*debug_apiv1.CreateStaffIDTokenResponse, error) {
-	idToken, err := h.debugInteractor.CreateStaffIDToken(ctx, req.GetEmail(), req.GetPassword())
-	if err != nil {
-		return nil, err
-	}
-	return &debug_apiv1.CreateStaffIDTokenResponse{
-		IdToken: idToken,
-	}, nil
-}
-
-func (h *DebugHandler) CreateStaffAuthUID(
-	ctx context.Context,
-	req *debug_apiv1.CreateStaffAuthUIDRequest,
-) (*debug_apiv1.CreateStaffAuthUIDResponse, error) {
-	authUID, err := h.debugInteractor.CreateStaffAuthUID(ctx, req.GetEmail(), req.GetPassword())
-	if err != nil {
-		return nil, err
-	}
-	return &debug_apiv1.CreateStaffAuthUIDResponse{
-		AuthUid: authUID,
-	}, nil
 }

--- a/internal/infrastructure/grpc/internal/handler/debug/id_token.go
+++ b/internal/infrastructure/grpc/internal/handler/debug/id_token.go
@@ -1,0 +1,40 @@
+package debug
+
+import (
+	"context"
+
+	debug_apiv1 "github.com/abyssparanoia/rapid-go/internal/infrastructure/grpc/pb/rapid/debug_api/v1"
+)
+
+func (h *DebugHandler) CreateAdminIDToken(ctx context.Context, req *debug_apiv1.CreateAdminIDTokenRequest) (*debug_apiv1.CreateAdminIDTokenResponse, error) {
+	idToken, err := h.debugInteractor.CreateAdminIDToken(ctx, req.GetEmail(), req.GetPassword())
+	if err != nil {
+		return nil, err
+	}
+	return &debug_apiv1.CreateAdminIDTokenResponse{
+		IdToken: idToken,
+	}, nil
+}
+
+func (h *DebugHandler) CreateStaffIDToken(ctx context.Context, req *debug_apiv1.CreateStaffIDTokenRequest) (*debug_apiv1.CreateStaffIDTokenResponse, error) {
+	idToken, err := h.debugInteractor.CreateStaffIDToken(ctx, req.GetEmail(), req.GetPassword())
+	if err != nil {
+		return nil, err
+	}
+	return &debug_apiv1.CreateStaffIDTokenResponse{
+		IdToken: idToken,
+	}, nil
+}
+
+func (h *DebugHandler) CreateStaffAuthUID(
+	ctx context.Context,
+	req *debug_apiv1.CreateStaffAuthUIDRequest,
+) (*debug_apiv1.CreateStaffAuthUIDResponse, error) {
+	authUID, err := h.debugInteractor.CreateStaffAuthUID(ctx, req.GetEmail(), req.GetPassword())
+	if err != nil {
+		return nil, err
+	}
+	return &debug_apiv1.CreateStaffAuthUIDResponse{
+		AuthUid: authUID,
+	}, nil
+}

--- a/internal/infrastructure/grpc/internal/handler/staff/me.go
+++ b/internal/infrastructure/grpc/internal/handler/staff/me.go
@@ -11,6 +11,30 @@ import (
 	"github.com/abyssparanoia/rapid-go/internal/usecase/input"
 )
 
+func (h *StaffHandler) GetMe(
+	ctx context.Context,
+	req *staff_apiv1.GetMeRequest,
+) (*staff_apiv1.GetMeResponse, error) {
+	claims, err := session_interceptor.RequireStaffSessionContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	requestTime := request_interceptor.GetRequestTime(ctx)
+
+	staff, err := h.meInteractor.Get(ctx, input.NewStaffGetMe(
+		claims.TenantID.String,
+		claims.StaffID.String,
+		requestTime,
+	))
+	if err != nil {
+		return nil, err
+	}
+
+	return &staff_apiv1.GetMeResponse{
+		Staff: marshaller.StaffToPB(staff),
+	}, nil
+}
+
 func (h *StaffHandler) SignUp(
 	ctx context.Context,
 	req *staff_apiv1.SignUpRequest,
@@ -34,30 +58,6 @@ func (h *StaffHandler) SignUp(
 	}
 
 	return &staff_apiv1.SignUpResponse{
-		Staff: marshaller.StaffToPB(staff),
-	}, nil
-}
-
-func (h *StaffHandler) GetMe(
-	ctx context.Context,
-	req *staff_apiv1.GetMeRequest,
-) (*staff_apiv1.GetMeResponse, error) {
-	claims, err := session_interceptor.RequireStaffSessionContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-	requestTime := request_interceptor.GetRequestTime(ctx)
-
-	staff, err := h.meInteractor.Get(ctx, input.NewStaffGetMe(
-		claims.TenantID.String,
-		claims.StaffID.String,
-		requestTime,
-	))
-	if err != nil {
-		return nil, err
-	}
-
-	return &staff_apiv1.GetMeResponse{
 		Staff: marshaller.StaffToPB(staff),
 	}, nil
 }

--- a/internal/infrastructure/grpc/internal/interceptor/request_interceptor/err_to_code.go
+++ b/internal/infrastructure/grpc/internal/interceptor/request_interceptor/err_to_code.go
@@ -21,6 +21,12 @@ func errToCode(err error) codes.Code {
 			return codes.AlreadyExists
 		case errors.ErrorCategoryInternal.String():
 			return codes.Internal
+		case errors.ErrorCategoryForbidden.String():
+			return codes.PermissionDenied
+		case errors.ErrorCategoryCanceled.String():
+			return codes.Canceled
+		case errors.ErrorCategoryServiceAvailable.String():
+			return codes.Unavailable
 		}
 	}
 	if status, ok := status.FromError(err); ok {

--- a/internal/infrastructure/http/json_test.go
+++ b/internal/infrastructure/http/json_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestCustomJSONPb_Int64AsNumber(t *testing.T) {
+	t.Parallel()
 	tests := map[string]func(t *testing.T){
 		"Int64AsNumber false - int64 fields are serialized as strings": func(t *testing.T) {
 			marshaler := &CustomJSONPb{
@@ -97,6 +98,9 @@ func TestCustomJSONPb_Int64AsNumber(t *testing.T) {
 	}
 
 	for name, tc := range tests {
-		t.Run(name, tc)
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			tc(t)
+		})
 	}
 }

--- a/internal/infrastructure/mysql/internal/marshaller/asset.go
+++ b/internal/infrastructure/mysql/internal/marshaller/asset.go
@@ -6,7 +6,7 @@ import (
 )
 
 func AssetToModel(e *dbmodel.Asset) *model.Asset {
-	m := &model.Asset{
+	return &model.Asset{
 		ID:          e.ID,
 		ContentType: model.NewContentType(e.ContentType),
 		Type:        model.NewAssetType(e.Type),
@@ -16,8 +16,6 @@ func AssetToModel(e *dbmodel.Asset) *model.Asset {
 		CreatedAt:   e.CreatedAt,
 		UpdatedAt:   e.UpdatedAt,
 	}
-
-	return m
 }
 
 func AssetsToModel(slice dbmodel.AssetSlice) model.Assets {

--- a/internal/infrastructure/mysql/repository/error_test.go
+++ b/internal/infrastructure/mysql/repository/error_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func Test_handleError(t *testing.T) {
+	t.Parallel()
 	testcase := map[string]struct {
 		err  error
 		want error
@@ -37,6 +38,7 @@ func Test_handleError(t *testing.T) {
 
 	for name, tc := range testcase {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			got := handleError(tc.err)
 			if got == nil {
 				if tc.want != nil {

--- a/internal/infrastructure/mysql/repository/tenant.go
+++ b/internal/infrastructure/mysql/repository/tenant.go
@@ -90,7 +90,7 @@ func (r *tenant) Count(
 	ctx context.Context,
 	query repository.ListTenantsQuery,
 ) (uint64, error) {
-	mods := []qm.QueryMod{}
+	mods := r.buildListQuery(query)
 	ttl, err := dbmodel.Tenants(
 		mods...,
 	).Count(ctx, transactable.GetContextExecutor(ctx))
@@ -98,6 +98,10 @@ func (r *tenant) Count(
 		return 0, errors.InternalErr.Wrap(err)
 	}
 	return uint64(ttl), nil
+}
+
+func (r *tenant) buildListQuery(_ repository.ListTenantsQuery) []qm.QueryMod {
+	return []qm.QueryMod{}
 }
 
 func (r *tenant) buildPreload(_ bool) []qm.QueryMod {

--- a/internal/infrastructure/postgresql/internal/marshaller/asset.go
+++ b/internal/infrastructure/postgresql/internal/marshaller/asset.go
@@ -6,7 +6,7 @@ import (
 )
 
 func AssetToModel(e *dbmodel.Asset) *model.Asset {
-	m := &model.Asset{
+	return &model.Asset{
 		ID:          e.ID,
 		ContentType: model.NewContentType(e.ContentType),
 		Type:        model.NewAssetType(e.Type),
@@ -16,8 +16,6 @@ func AssetToModel(e *dbmodel.Asset) *model.Asset {
 		CreatedAt:   e.CreatedAt,
 		UpdatedAt:   e.UpdatedAt,
 	}
-
-	return m
 }
 
 func AssetsToModel(slice dbmodel.AssetSlice) model.Assets {

--- a/internal/infrastructure/postgresql/repository/admin.go
+++ b/internal/infrastructure/postgresql/repository/admin.go
@@ -61,13 +61,13 @@ func (r *admin) List(
 	if query.SortKey.Valid && query.SortKey.Value().Valid() {
 		switch query.SortKey.Value() {
 		case model.AdminSortKeyCreatedAtDesc:
-			mods = append(mods, qm.OrderBy("\"created_at\" DESC"))
+			mods = append(mods, qm.OrderBy("\""+dbmodel.AdminColumns.CreatedAt+"\" DESC"))
 		case model.AdminSortKeyCreatedAtAsc:
-			mods = append(mods, qm.OrderBy("\"created_at\" ASC"))
+			mods = append(mods, qm.OrderBy("\""+dbmodel.AdminColumns.CreatedAt+"\" ASC"))
 		case model.AdminSortKeyDisplayNameAsc:
-			mods = append(mods, qm.OrderBy("\"display_name\" ASC"))
+			mods = append(mods, qm.OrderBy("\""+dbmodel.AdminColumns.DisplayName+"\" ASC"))
 		case model.AdminSortKeyDisplayNameDesc:
-			mods = append(mods, qm.OrderBy("\"display_name\" DESC"))
+			mods = append(mods, qm.OrderBy("\""+dbmodel.AdminColumns.DisplayName+"\" DESC"))
 		case model.AdminSortKeyUnknown:
 			return nil, errors.InternalErr.Errorf("invalid sort key: %s", query.SortKey.Value())
 		}

--- a/internal/infrastructure/postgresql/repository/error_test.go
+++ b/internal/infrastructure/postgresql/repository/error_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func Test_handleError(t *testing.T) {
+	t.Parallel()
 	testcase := map[string]struct {
 		err  error
 		want error
@@ -37,6 +38,7 @@ func Test_handleError(t *testing.T) {
 
 	for name, tc := range testcase {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			got := handleError(tc.err)
 			if got == nil {
 				if tc.want != nil {

--- a/internal/infrastructure/postgresql/repository/staff.go
+++ b/internal/infrastructure/postgresql/repository/staff.go
@@ -60,13 +60,13 @@ func (r *staff) List(
 	if query.SortKey.Valid && query.SortKey.Value().Valid() {
 		switch query.SortKey.Value() {
 		case model.StaffSortKeyCreatedAtDesc:
-			mods = append(mods, qm.OrderBy("\"created_at\" DESC"))
+			mods = append(mods, qm.OrderBy("\""+dbmodel.StaffColumns.CreatedAt+"\" DESC"))
 		case model.StaffSortKeyCreatedAtAsc:
-			mods = append(mods, qm.OrderBy("\"created_at\" ASC"))
+			mods = append(mods, qm.OrderBy("\""+dbmodel.StaffColumns.CreatedAt+"\" ASC"))
 		case model.StaffSortKeyDisplayNameAsc:
-			mods = append(mods, qm.OrderBy("\"display_name\" ASC"))
+			mods = append(mods, qm.OrderBy("\""+dbmodel.StaffColumns.DisplayName+"\" ASC"))
 		case model.StaffSortKeyDisplayNameDesc:
-			mods = append(mods, qm.OrderBy("\"display_name\" DESC"))
+			mods = append(mods, qm.OrderBy("\""+dbmodel.StaffColumns.DisplayName+"\" DESC"))
 		case model.StaffSortKeyUnknown:
 			return nil, errors.InternalErr.Errorf("invalid sort key: %s", query.SortKey.Value())
 		}

--- a/internal/infrastructure/postgresql/repository/tenant.go
+++ b/internal/infrastructure/postgresql/repository/tenant.go
@@ -56,13 +56,13 @@ func (r *tenant) List(
 	if query.SortKey.Valid && query.SortKey.Value().Valid() {
 		switch query.SortKey.Value() {
 		case model.TenantSortKeyCreatedAtDesc:
-			mods = append(mods, qm.OrderBy("\"created_at\" DESC"))
+			mods = append(mods, qm.OrderBy("\""+dbmodel.TenantColumns.CreatedAt+"\" DESC"))
 		case model.TenantSortKeyCreatedAtAsc:
-			mods = append(mods, qm.OrderBy("\"created_at\" ASC"))
+			mods = append(mods, qm.OrderBy("\""+dbmodel.TenantColumns.CreatedAt+"\" ASC"))
 		case model.TenantSortKeyNameAsc:
-			mods = append(mods, qm.OrderBy("\"name\" ASC"))
+			mods = append(mods, qm.OrderBy("\""+dbmodel.TenantColumns.Name+"\" ASC"))
 		case model.TenantSortKeyNameDesc:
-			mods = append(mods, qm.OrderBy("\"name\" DESC"))
+			mods = append(mods, qm.OrderBy("\""+dbmodel.TenantColumns.Name+"\" DESC"))
 		case model.TenantSortKeyUnknown:
 			return nil, errors.InternalErr.Errorf("invalid sort key: %s", query.SortKey.Value())
 		}
@@ -90,7 +90,7 @@ func (r *tenant) Count(
 	ctx context.Context,
 	query repository.ListTenantsQuery,
 ) (uint64, error) {
-	mods := []qm.QueryMod{}
+	mods := r.buildListQuery(query)
 	ttl, err := dbmodel.Tenants(
 		mods...,
 	).Count(ctx, transactable.GetContextExecutor(ctx))
@@ -98,6 +98,10 @@ func (r *tenant) Count(
 		return 0, errors.InternalErr.Wrap(err)
 	}
 	return uint64(ttl), nil
+}
+
+func (r *tenant) buildListQuery(_ repository.ListTenantsQuery) []qm.QueryMod {
+	return []qm.QueryMod{}
 }
 
 func (r *tenant) buildPreload(_ bool) []qm.QueryMod {

--- a/internal/infrastructure/redis/helper/transaction.go
+++ b/internal/infrastructure/redis/helper/transaction.go
@@ -2,7 +2,6 @@ package redis_helper
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/abyssparanoia/rapid-go/internal/domain/errors"
 	"github.com/cenkalti/backoff"
@@ -24,7 +23,7 @@ func RunTransaction(ctx context.Context, redisClient *redis.Client, fn func(ctx 
 		}
 		return nil
 	}, b); err != nil {
-		return fmt.Errorf("transaction failed: %w", err)
+		return errors.InternalErr.Wrap(err).WithDetail("transaction failed")
 	}
 	return nil
 }

--- a/internal/usecase/admin_asset.go
+++ b/internal/usecase/admin_asset.go
@@ -7,6 +7,7 @@ import (
 	"github.com/abyssparanoia/rapid-go/internal/usecase/output"
 )
 
+//go:generate go run go.uber.org/mock/mockgen -source=$GOFILE -destination=mock/$GOFILE -package=mock_usecase
 type AdminAssetInteractor interface {
 	CreatePresignedURL(
 		ctx context.Context,

--- a/internal/usecase/admin_asset_impl_test.go
+++ b/internal/usecase/admin_asset_impl_test.go
@@ -66,7 +66,7 @@ func TestAdminAssetInteractor_CreatePresignedURL(t *testing.T) {
 
 			mockAssetService := mock_service.NewMockAsset(ctrl)
 			mockAssetService.EXPECT().
-				CreatePresignedURL(gomock.Any(), assetType, contentType, gomock.Any(), testdata.RequestTime).
+				CreatePresignedURL(gomock.Any(), assetType, contentType, model.NewAdminAssetAuthContext(testdata.Admin.ID), testdata.RequestTime).
 				Return(nil, errors.InternalErr.New())
 
 			return testcase{
@@ -98,7 +98,7 @@ func TestAdminAssetInteractor_CreatePresignedURL(t *testing.T) {
 
 			mockAssetService := mock_service.NewMockAsset(ctrl)
 			mockAssetService.EXPECT().
-				CreatePresignedURL(gomock.Any(), assetType, contentType, gomock.Any(), testdata.RequestTime).
+				CreatePresignedURL(gomock.Any(), assetType, contentType, model.NewAdminAssetAuthContext(testdata.Admin.ID), testdata.RequestTime).
 				Return(serviceResult, nil)
 
 			return testcase{
@@ -121,7 +121,7 @@ func TestAdminAssetInteractor_CreatePresignedURL(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := t.Context()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 

--- a/internal/usecase/admin_authentication_impl_test.go
+++ b/internal/usecase/admin_authentication_impl_test.go
@@ -102,7 +102,7 @@ func TestAdminAuthenticationInteractor_VerifyAdminIDToken(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := t.Context()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 

--- a/internal/usecase/admin_staff_impl_test.go
+++ b/internal/usecase/admin_staff_impl_test.go
@@ -345,7 +345,7 @@ func TestAdminStaffInteractor_Create(t *testing.T) {
 
 			mockAssetService := mock_service.NewMockAsset(ctrl)
 			mockAssetService.EXPECT().
-				GetWithValidate(gomock.Any(), model.AssetTypeUserImage, staff.ImagePath, gomock.Any()).
+				GetWithValidate(gomock.Any(), model.AssetTypeUserImage, staff.ImagePath, model.NewAdminAssetAuthContext(admin.ID)).
 				Return(staff.ImagePath, func() {}, nil)
 
 			mockStaffService := mock_service.NewMockStaff(ctrl)
@@ -500,7 +500,7 @@ func TestAdminStaffInteractor_Update(t *testing.T) {
 			mockStaffService := mock_service.NewMockStaff(ctrl)
 			mockAssetService := mock_service.NewMockAsset(ctrl)
 			mockAssetService.EXPECT().
-				GetWithValidate(gomock.Any(), model.AssetTypeUserImage, staff.ImagePath, gomock.Any()).
+				GetWithValidate(gomock.Any(), model.AssetTypeUserImage, staff.ImagePath, model.NewAdminAssetAuthContext(admin.ID)).
 				Return(staff.ImagePath, func() {}, nil)
 			mockAssetService.EXPECT().
 				BatchSetStaffURLs(gomock.Any(), model.Staffs{staff}, gomock.Any()).

--- a/internal/usecase/admin_tenant.go
+++ b/internal/usecase/admin_tenant.go
@@ -8,6 +8,7 @@ import (
 	"github.com/abyssparanoia/rapid-go/internal/usecase/output"
 )
 
+//go:generate go run go.uber.org/mock/mockgen -source=$GOFILE -destination=mock/$GOFILE -package=mock_usecase
 type AdminTenantInteractor interface {
 	Get(
 		ctx context.Context,

--- a/internal/usecase/admin_tenant_impl.go
+++ b/internal/usecase/admin_tenant_impl.go
@@ -40,10 +40,11 @@ func (i *adminTenantInteractor) Get(
 	tenant, err := i.tenantRepository.Get(
 		ctx,
 		repository.GetTenantQuery{
-			ID: null.StringFrom(param.TenantID),
 			BaseGetOptions: repository.BaseGetOptions{
-				OrFail: true,
+				OrFail:  true,
+				Preload: true,
 			},
+			ID: null.StringFrom(param.TenantID),
 		},
 	)
 	if err != nil {
@@ -64,8 +65,9 @@ func (i *adminTenantInteractor) List(
 	}
 	query := repository.ListTenantsQuery{
 		BaseListOptions: repository.BaseListOptions{
-			Page:  null.Uint64From(param.Page),
-			Limit: null.Uint64From(param.Limit),
+			Page:    null.Uint64From(param.Page),
+			Limit:   null.Uint64From(param.Limit),
+			Preload: true,
 		},
 		SortKey: nullable.TypeFrom(param.SortKey),
 	}
@@ -104,7 +106,19 @@ func (i *adminTenantInteractor) Create(
 		return nil, err
 	}
 	tenant := model.NewTenant(param.Name, param.RequestTime)
-	if err := i.tenantRepository.Create(ctx, tenant); err != nil {
+	if err := i.transactable.RWTx(ctx, func(ctx context.Context) error {
+		return i.tenantRepository.Create(ctx, tenant)
+	}); err != nil {
+		return nil, err
+	}
+	tenant, err := i.tenantRepository.Get(ctx, repository.GetTenantQuery{
+		BaseGetOptions: repository.BaseGetOptions{
+			OrFail:  true,
+			Preload: true,
+		},
+		ID: null.StringFrom(tenant.ID),
+	})
+	if err != nil {
 		return nil, err
 	}
 	if err := i.assetService.BatchSetTenantURLs(ctx, model.Tenants{tenant}, param.RequestTime); err != nil {
@@ -120,17 +134,15 @@ func (i *adminTenantInteractor) Update(
 	if err := param.Validate(); err != nil {
 		return nil, err
 	}
-	var tenant *model.Tenant
 	if err := i.transactable.RWTx(ctx, func(ctx context.Context) error {
-		var err error
-		tenant, err = i.tenantRepository.Get(
+		tenant, err := i.tenantRepository.Get(
 			ctx,
 			repository.GetTenantQuery{
-				ID: null.StringFrom(param.TenantID),
 				BaseGetOptions: repository.BaseGetOptions{
 					OrFail:    true,
 					ForUpdate: true,
 				},
+				ID: null.StringFrom(param.TenantID),
 			},
 		)
 		if err != nil {
@@ -140,11 +152,18 @@ func (i *adminTenantInteractor) Update(
 			param.Name,
 			param.RequestTime,
 		)
-		if err := i.tenantRepository.Update(ctx, tenant); err != nil {
-			return err
-		}
-		return nil
+		return i.tenantRepository.Update(ctx, tenant)
 	}); err != nil {
+		return nil, err
+	}
+	tenant, err := i.tenantRepository.Get(ctx, repository.GetTenantQuery{
+		BaseGetOptions: repository.BaseGetOptions{
+			OrFail:  true,
+			Preload: true,
+		},
+		ID: null.StringFrom(param.TenantID),
+	})
+	if err != nil {
 		return nil, err
 	}
 	if err := i.assetService.BatchSetTenantURLs(ctx, model.Tenants{tenant}, param.RequestTime); err != nil {
@@ -160,5 +179,17 @@ func (i *adminTenantInteractor) Delete(
 	if err := param.Validate(); err != nil {
 		return err
 	}
-	return i.tenantRepository.Delete(ctx, param.TenantID)
+	return i.transactable.RWTx(ctx, func(ctx context.Context) error {
+		_, err := i.tenantRepository.Get(ctx, repository.GetTenantQuery{
+			BaseGetOptions: repository.BaseGetOptions{
+				OrFail:    true,
+				ForUpdate: true,
+			},
+			ID: null.StringFrom(param.TenantID),
+		})
+		if err != nil {
+			return err
+		}
+		return i.tenantRepository.Delete(ctx, param.TenantID)
+	})
 }

--- a/internal/usecase/admin_tenant_impl_test.go
+++ b/internal/usecase/admin_tenant_impl_test.go
@@ -65,10 +65,11 @@ func TestAdminAdminTenantInteractor_Get(t *testing.T) {
 			mockTenantRepo.EXPECT().
 				Get(gomock.Any(),
 					repository.GetTenantQuery{
-						ID: null.StringFrom(tenant.ID),
 						BaseGetOptions: repository.BaseGetOptions{
-							OrFail: true,
+							OrFail:  true,
+							Preload: true,
 						},
+						ID: null.StringFrom(tenant.ID),
 					}).
 				Return(nil, errors.TenantNotFoundErr)
 			mockAssetService := mock_service.NewMockAsset(ctrl)
@@ -96,10 +97,11 @@ func TestAdminAdminTenantInteractor_Get(t *testing.T) {
 			mockTenantRepo.EXPECT().
 				Get(gomock.Any(),
 					repository.GetTenantQuery{
-						ID: null.StringFrom(tenant.ID),
 						BaseGetOptions: repository.BaseGetOptions{
-							OrFail: true,
+							OrFail:  true,
+							Preload: true,
 						},
+						ID: null.StringFrom(tenant.ID),
 					}).
 				Return(tenant, nil)
 			mockAssetService := mock_service.NewMockAsset(ctrl)
@@ -177,8 +179,9 @@ func TestAdminAdminTenantInteractor_List(t *testing.T) {
 					gomock.Any(),
 					repository.ListTenantsQuery{
 						BaseListOptions: repository.BaseListOptions{
-							Page:  null.Uint64From(2),
-							Limit: null.Uint64From(30),
+							Page:    null.Uint64From(2),
+							Limit:   null.Uint64From(30),
+							Preload: true,
 						},
 						SortKey: nullable.TypeFrom(model.TenantSortKeyCreatedAtDesc),
 					}).
@@ -189,8 +192,9 @@ func TestAdminAdminTenantInteractor_List(t *testing.T) {
 					gomock.Any(),
 					repository.ListTenantsQuery{
 						BaseListOptions: repository.BaseListOptions{
-							Page:  null.Uint64From(2),
-							Limit: null.Uint64From(30),
+							Page:    null.Uint64From(2),
+							Limit:   null.Uint64From(30),
+							Preload: true,
 						},
 						SortKey: nullable.TypeFrom(model.TenantSortKeyCreatedAtDesc),
 					},
@@ -288,10 +292,20 @@ func TestAdminAdminTenantInteractor_Create(t *testing.T) {
 			tenant.ID = mockID
 			tenant.Tags = model.TenantTags{}
 
+			mockTransactable := mock_repository.TestMockTransactable()
 			mockTenantRepo := mock_repository.NewMockTenant(ctrl)
 			mockTenantRepo.EXPECT().
 				Create(gomock.Any(), tenant).
 				Return(nil)
+			mockTenantRepo.EXPECT().
+				Get(gomock.Any(), repository.GetTenantQuery{
+					BaseGetOptions: repository.BaseGetOptions{
+						OrFail:  true,
+						Preload: true,
+					},
+					ID: null.StringFrom(tenant.ID),
+				}).
+				Return(tenant, nil)
 			mockAssetService := mock_service.NewMockAsset(ctrl)
 			mockAssetService.EXPECT().
 				BatchSetTenantURLs(gomock.Any(), model.Tenants{tenant}, gomock.Any()).
@@ -303,6 +317,7 @@ func TestAdminAdminTenantInteractor_Create(t *testing.T) {
 					requestTime: requestTime,
 				},
 				usecase: &adminTenantInteractor{
+					transactable:     mockTransactable,
 					tenantRepository: mockTenantRepo,
 					assetService:     mockAssetService,
 				},
@@ -381,16 +396,26 @@ func TestAdminAdminTenantInteractor_Update(t *testing.T) {
 			mockTenantRepo.EXPECT().
 				Get(gomock.Any(),
 					repository.GetTenantQuery{
-						ID: null.StringFrom(tenant.ID),
 						BaseGetOptions: repository.BaseGetOptions{
 							OrFail:    true,
 							ForUpdate: true,
 						},
+						ID: null.StringFrom(tenant.ID),
 					}).
 				Return(tenant, nil)
 			mockTenantRepo.EXPECT().
 				Update(gomock.Any(), updatedTenant).
 				Return(nil)
+			mockTenantRepo.EXPECT().
+				Get(gomock.Any(),
+					repository.GetTenantQuery{
+						BaseGetOptions: repository.BaseGetOptions{
+							OrFail:  true,
+							Preload: true,
+						},
+						ID: null.StringFrom(tenant.ID),
+					}).
+				Return(updatedTenant, nil)
 			mockAssetService := mock_service.NewMockAsset(ctrl)
 			mockAssetService.EXPECT().
 				BatchSetTenantURLs(gomock.Any(), model.Tenants{updatedTenant}, gomock.Any()).
@@ -442,7 +467,8 @@ func TestAdminAdminTenantInteractor_Delete(t *testing.T) {
 	t.Parallel()
 
 	type args struct {
-		tenantID string
+		tenantID    string
+		requestTime time.Time
 	}
 
 	type want struct {
@@ -471,7 +497,22 @@ func TestAdminAdminTenantInteractor_Delete(t *testing.T) {
 			testdata := factory.NewFactory()
 			tenant := testdata.Tenant
 
+			mockTransactable := mock_repository.NewMockTransactable(ctrl)
+			mockTransactable.EXPECT().RWTx(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, fn func(context.Context) error) error {
+					return fn(ctx)
+				},
+			)
 			mockTenantRepo := mock_repository.NewMockTenant(ctrl)
+			mockTenantRepo.EXPECT().
+				Get(gomock.Any(), repository.GetTenantQuery{
+					BaseGetOptions: repository.BaseGetOptions{
+						OrFail:    true,
+						ForUpdate: true,
+					},
+					ID: null.StringFrom(tenant.ID),
+				}).
+				Return(tenant, nil)
 			mockTenantRepo.EXPECT().
 				Delete(gomock.Any(), tenant.ID).
 				Return(nil)
@@ -479,9 +520,11 @@ func TestAdminAdminTenantInteractor_Delete(t *testing.T) {
 
 			return testcase{
 				args: args{
-					tenantID: tenant.ID,
+					tenantID:    tenant.ID,
+					requestTime: testdata.RequestTime,
 				},
 				usecase: &adminTenantInteractor{
+					transactable:     mockTransactable,
 					tenantRepository: mockTenantRepo,
 					assetService:     mockAssetService,
 				},
@@ -501,6 +544,7 @@ func TestAdminAdminTenantInteractor_Delete(t *testing.T) {
 
 			err := tc.usecase.Delete(ctx, input.NewAdminDeleteTenant(
 				tc.args.tenantID,
+				tc.args.requestTime,
 			))
 			if tc.want.expectedResult == nil {
 				require.NoError(t, err)

--- a/internal/usecase/authentication.go
+++ b/internal/usecase/authentication.go
@@ -7,6 +7,7 @@ import (
 	"github.com/abyssparanoia/rapid-go/internal/usecase/input"
 )
 
+//go:generate go run go.uber.org/mock/mockgen -source=$GOFILE -destination=mock/$GOFILE -package=mock_usecase
 type AuthenticationInteractor interface {
 	VerifyStaffIDToken(
 		ctx context.Context,

--- a/internal/usecase/authentication_impl_test.go
+++ b/internal/usecase/authentication_impl_test.go
@@ -104,7 +104,7 @@ func TestAuthenticationInteractor_VerifyStaffIDToken(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := t.Context()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 

--- a/internal/usecase/debug.go
+++ b/internal/usecase/debug.go
@@ -2,6 +2,7 @@ package usecase
 
 import "context"
 
+//go:generate go run go.uber.org/mock/mockgen -source=$GOFILE -destination=mock/$GOFILE -package=mock_usecase
 type DebugInteractor interface {
 	CreateAdminIDToken(
 		ctx context.Context,

--- a/internal/usecase/debug_impl_test.go
+++ b/internal/usecase/debug_impl_test.go
@@ -84,7 +84,7 @@ func TestDebugInteractor_CreateAdminIDToken(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := t.Context()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
@@ -176,7 +176,7 @@ func TestDebugInteractor_CreateStaffIDToken(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := t.Context()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 

--- a/internal/usecase/input/admin_tenant.go
+++ b/internal/usecase/input/admin_tenant.go
@@ -122,14 +122,17 @@ func (p *AdminUpdateTenant) Validate() error {
 }
 
 type AdminDeleteTenant struct {
-	TenantID string `validate:"required"`
+	TenantID    string    `validate:"required"`
+	RequestTime time.Time `validate:"required"`
 }
 
 func NewAdminDeleteTenant(
 	tenantID string,
+	requestTime time.Time,
 ) *AdminDeleteTenant {
 	return &AdminDeleteTenant{
-		TenantID: tenantID,
+		TenantID:    tenantID,
+		RequestTime: requestTime,
 	}
 }
 

--- a/internal/usecase/staff_asset_impl_test.go
+++ b/internal/usecase/staff_asset_impl_test.go
@@ -66,7 +66,7 @@ func TestStaffAssetInteractor_CreatePresignedURL(t *testing.T) {
 
 			mockAssetService := mock_service.NewMockAsset(ctrl)
 			mockAssetService.EXPECT().
-				CreatePresignedURL(gomock.Any(), assetType, contentType, gomock.Any(), testdata.RequestTime).
+				CreatePresignedURL(gomock.Any(), assetType, contentType, model.NewStaffAssetAuthContext(testdata.Staff.ID), testdata.RequestTime).
 				Return(nil, errors.InternalErr.New())
 
 			return testcase{
@@ -98,7 +98,7 @@ func TestStaffAssetInteractor_CreatePresignedURL(t *testing.T) {
 
 			mockAssetService := mock_service.NewMockAsset(ctrl)
 			mockAssetService.EXPECT().
-				CreatePresignedURL(gomock.Any(), assetType, contentType, gomock.Any(), testdata.RequestTime).
+				CreatePresignedURL(gomock.Any(), assetType, contentType, model.NewStaffAssetAuthContext(testdata.Staff.ID), testdata.RequestTime).
 				Return(serviceResult, nil)
 
 			return testcase{
@@ -121,7 +121,7 @@ func TestStaffAssetInteractor_CreatePresignedURL(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := t.Context()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 

--- a/internal/usecase/staff_me.go
+++ b/internal/usecase/staff_me.go
@@ -9,13 +9,13 @@ import (
 
 //go:generate go run go.uber.org/mock/mockgen -source=$GOFILE -destination=mock/$GOFILE -package=mock_usecase
 type StaffMeInteractor interface {
-	SignUp(
-		ctx context.Context,
-		param *input.StaffSignUp,
-	) (*model.Staff, error)
 	Get(
 		ctx context.Context,
 		param *input.StaffGetMe,
+	) (*model.Staff, error)
+	SignUp(
+		ctx context.Context,
+		param *input.StaffSignUp,
 	) (*model.Staff, error)
 	Update(
 		ctx context.Context,

--- a/internal/usecase/staff_me_impl.go
+++ b/internal/usecase/staff_me_impl.go
@@ -35,6 +35,33 @@ func NewStaffMeInteractor(
 	}
 }
 
+func (i *staffMeInteractor) Get(
+	ctx context.Context,
+	param *input.StaffGetMe,
+) (*model.Staff, error) {
+	if err := param.Validate(); err != nil {
+		return nil, err
+	}
+
+	staff, err := i.staffRepository.Get(ctx, repository.GetStaffQuery{
+		ID: null.StringFrom(param.StaffID),
+		BaseGetOptions: repository.BaseGetOptions{
+			OrFail:  true,
+			Preload: true,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Apply asset URL processing
+	if err := i.assetService.BatchSetStaffURLs(ctx, model.Staffs{staff}, param.RequestTime); err != nil {
+		return nil, err
+	}
+
+	return staff, nil
+}
+
 func (i *staffMeInteractor) SignUp(
 	ctx context.Context,
 	param *input.StaffSignUp,
@@ -44,18 +71,18 @@ func (i *staffMeInteractor) SignUp(
 		return nil, err
 	}
 
-	// 2. Validate asset
-	authContext := model.NewStaffAssetAuthContext(param.AuthUID)
-	imagePath, clearAssetPath, err := i.assetService.GetWithValidate(ctx, model.AssetTypeUserImage, param.ImageAssetID, authContext)
-	if err != nil {
-		return nil, err
-	}
-	defer clearAssetPath()
-
 	var staff *model.Staff
 
-	// 3. Create tenant and staff in transaction
+	// 2. Create tenant and staff in transaction (asset validation inside)
 	txErr := i.transactable.RWTx(ctx, func(ctx context.Context) error {
+		// Validate asset inside transaction
+		authContext := model.NewStaffAssetAuthContext(param.AuthUID)
+		imagePath, clearAssetPath, err := i.assetService.GetWithValidate(ctx, model.AssetTypeUserImage, param.ImageAssetID, authContext)
+		if err != nil {
+			return err
+		}
+		defer clearAssetPath()
+
 		// Create new tenant
 		tenant := model.NewTenant(
 			param.TenantName,
@@ -86,8 +113,8 @@ func (i *staffMeInteractor) SignUp(
 		return nil, txErr
 	}
 
-	// 4. Return staff with relations loaded
-	staff, err = i.staffRepository.Get(ctx, repository.GetStaffQuery{
+	// 3. Return staff with relations loaded
+	staff, err := i.staffRepository.Get(ctx, repository.GetStaffQuery{
 		ID: null.StringFrom(staff.ID),
 		BaseGetOptions: repository.BaseGetOptions{
 			OrFail:  true,
@@ -98,34 +125,7 @@ func (i *staffMeInteractor) SignUp(
 		return nil, err
 	}
 
-	// 5. Apply asset URL processing
-	if err := i.assetService.BatchSetStaffURLs(ctx, model.Staffs{staff}, param.RequestTime); err != nil {
-		return nil, err
-	}
-
-	return staff, nil
-}
-
-func (i *staffMeInteractor) Get(
-	ctx context.Context,
-	param *input.StaffGetMe,
-) (*model.Staff, error) {
-	if err := param.Validate(); err != nil {
-		return nil, err
-	}
-
-	staff, err := i.staffRepository.Get(ctx, repository.GetStaffQuery{
-		ID: null.StringFrom(param.StaffID),
-		BaseGetOptions: repository.BaseGetOptions{
-			OrFail:  true,
-			Preload: true,
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Apply asset URL processing
+	// 4. Apply asset URL processing
 	if err := i.assetService.BatchSetStaffURLs(ctx, model.Staffs{staff}, param.RequestTime); err != nil {
 		return nil, err
 	}

--- a/internal/usecase/staff_me_impl_test.go
+++ b/internal/usecase/staff_me_impl_test.go
@@ -113,7 +113,7 @@ func TestStaffMeInteractor_SignUp(t *testing.T) {
 				Return(staff, nil)
 			mockAssetService := mock_service.NewMockAsset(ctrl)
 			mockAssetService.EXPECT().
-				GetWithValidate(gomock.Any(), model.AssetTypeUserImage, "image-asset-id", gomock.Any()).
+				GetWithValidate(gomock.Any(), model.AssetTypeUserImage, "image-asset-id", model.NewStaffAssetAuthContext("auth-uid")).
 				Return("/path/to/image", func() {}, nil)
 			mockAssetService.EXPECT().
 				BatchSetStaffURLs(gomock.Any(), model.Staffs{staff}, gomock.Any()).
@@ -145,7 +145,7 @@ func TestStaffMeInteractor_SignUp(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := t.Context()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
@@ -306,7 +306,7 @@ func TestStaffMeInteractor_Get(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := t.Context()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
@@ -461,7 +461,7 @@ func TestStaffMeInteractor_Update(t *testing.T) {
 			mockStaffService := mock_service.NewMockStaff(ctrl)
 			mockAssetService := mock_service.NewMockAsset(ctrl)
 			mockAssetService.EXPECT().
-				GetWithValidate(gomock.Any(), model.AssetTypeUserImage, "image-asset-id", gomock.Any()).
+				GetWithValidate(gomock.Any(), model.AssetTypeUserImage, "image-asset-id", model.NewStaffAssetAuthContext(staff.ID)).
 				Return("/path/to/image", func() {}, nil)
 			mockAssetService.EXPECT().
 				BatchSetStaffURLs(gomock.Any(), model.Staffs{updatedStaff}, gomock.Any()).
@@ -492,7 +492,7 @@ func TestStaffMeInteractor_Update(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := t.Context()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 

--- a/internal/usecase/staff_me_tenant_impl_test.go
+++ b/internal/usecase/staff_me_tenant_impl_test.go
@@ -142,7 +142,7 @@ func TestStaffMeTenantInteractor_Get(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := t.Context()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
@@ -309,7 +309,7 @@ func TestStaffMeTenantInteractor_Update(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := t.Context()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 

--- a/internal/usecase/staff_staff_impl.go
+++ b/internal/usecase/staff_staff_impl.go
@@ -13,26 +13,17 @@ import (
 )
 
 type staffStaffInteractor struct {
-	transactable     repository.Transactable
-	tenantRepository repository.Tenant
-	staffRepository  repository.Staff
-	staffService     service.Staff
-	assetService     service.Asset
+	staffRepository repository.Staff
+	assetService    service.Asset
 }
 
 func NewStaffStaffInteractor(
-	transactable repository.Transactable,
-	tenantRepository repository.Tenant,
 	staffRepository repository.Staff,
-	staffService service.Staff,
 	assetService service.Asset,
 ) StaffStaffInteractor {
 	return &staffStaffInteractor{
-		transactable,
-		tenantRepository,
-		staffRepository,
-		staffService,
-		assetService,
+		staffRepository: staffRepository,
+		assetService:    assetService,
 	}
 }
 

--- a/internal/usecase/staff_staff_impl_test.go
+++ b/internal/usecase/staff_staff_impl_test.go
@@ -45,20 +45,14 @@ func TestStaffStaffInteractor_Get(t *testing.T) {
 
 	tests := map[string]testcaseFunc{
 		"invalid argument": func(ctx context.Context, ctrl *gomock.Controller) testcase {
-			mockTransactable := mock_repository.NewMockTransactable(ctrl)
-			mockTenantRepo := mock_repository.NewMockTenant(ctrl)
 			mockStaffRepo := mock_repository.NewMockStaff(ctrl)
-			mockStaffService := mock_service.NewMockStaff(ctrl)
 			mockAssetService := mock_service.NewMockAsset(ctrl)
 
 			return testcase{
 				args: args{},
 				usecase: &staffStaffInteractor{
-					transactable:     mockTransactable,
-					tenantRepository: mockTenantRepo,
-					staffRepository:  mockStaffRepo,
-					staffService:     mockStaffService,
-					assetService:     mockAssetService,
+					staffRepository: mockStaffRepo,
+					assetService:    mockAssetService,
 				},
 				want: want{
 					expectedResult: errors.RequestInvalidArgumentErr,
@@ -83,9 +77,6 @@ func TestStaffStaffInteractor_Get(t *testing.T) {
 					}).
 				Return(nil, errors.StaffNotFoundErr)
 
-			mockTransactable := mock_repository.NewMockTransactable(ctrl)
-			mockTenantRepo := mock_repository.NewMockTenant(ctrl)
-			mockStaffService := mock_service.NewMockStaff(ctrl)
 			mockAssetService := mock_service.NewMockAsset(ctrl)
 
 			return testcase{
@@ -96,11 +87,8 @@ func TestStaffStaffInteractor_Get(t *testing.T) {
 					requestTime:   testdata.RequestTime,
 				},
 				usecase: &staffStaffInteractor{
-					transactable:     mockTransactable,
-					tenantRepository: mockTenantRepo,
-					staffRepository:  mockStaffRepo,
-					staffService:     mockStaffService,
-					assetService:     mockAssetService,
+					staffRepository: mockStaffRepo,
+					assetService:    mockAssetService,
 				},
 				want: want{
 					expectedResult: errors.StaffNotFoundErr,
@@ -125,9 +113,6 @@ func TestStaffStaffInteractor_Get(t *testing.T) {
 					}).
 				Return(staff, nil)
 
-			mockTransactable := mock_repository.NewMockTransactable(ctrl)
-			mockTenantRepo := mock_repository.NewMockTenant(ctrl)
-			mockStaffService := mock_service.NewMockStaff(ctrl)
 			mockAssetService := mock_service.NewMockAsset(ctrl)
 			mockAssetService.EXPECT().
 				BatchSetStaffURLs(gomock.Any(), model.Staffs{staff}, gomock.Any()).
@@ -141,11 +126,8 @@ func TestStaffStaffInteractor_Get(t *testing.T) {
 					requestTime:   testdata.RequestTime,
 				},
 				usecase: &staffStaffInteractor{
-					transactable:     mockTransactable,
-					tenantRepository: mockTenantRepo,
-					staffRepository:  mockStaffRepo,
-					staffService:     mockStaffService,
-					assetService:     mockAssetService,
+					staffRepository: mockStaffRepo,
+					assetService:    mockAssetService,
 				},
 				want: want{
 					staff: staff,
@@ -157,7 +139,7 @@ func TestStaffStaffInteractor_Get(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := t.Context()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
@@ -244,9 +226,6 @@ func TestStaffStaffInteractor_List(t *testing.T) {
 					}).
 				Return(uint64(60), nil)
 
-			mockTransactable := mock_repository.NewMockTransactable(ctrl)
-			mockTenantRepo := mock_repository.NewMockTenant(ctrl)
-			mockStaffService := mock_service.NewMockStaff(ctrl)
 			mockAssetService := mock_service.NewMockAsset(ctrl)
 			mockAssetService.EXPECT().
 				BatchSetStaffURLs(gomock.Any(), model.Staffs{staff}, gomock.Any()).
@@ -262,11 +241,8 @@ func TestStaffStaffInteractor_List(t *testing.T) {
 					requestTime: testdata.RequestTime,
 				},
 				usecase: &staffStaffInteractor{
-					transactable:     mockTransactable,
-					tenantRepository: mockTenantRepo,
-					staffRepository:  mockStaffRepo,
-					staffService:     mockStaffService,
-					assetService:     mockAssetService,
+					staffRepository: mockStaffRepo,
+					assetService:    mockAssetService,
 				},
 				want: want{
 					output: output.NewStaffListStaffs(
@@ -281,7 +257,7 @@ func TestStaffStaffInteractor_List(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := t.Context()
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 


### PR DESCRIPTION
## Proposed Changes

- Auto-fixed rule-compliance violations detected by `/audit-rules`
- Partitions audited: domain, usecase, grpc, db-repo, proto, migration, infra-other, tests

## Implementation

### Audit Results

| Partition | Files | Findings | Auto-Fixed |
|-----------|-------|----------|------------|
| domain | 33 | 10 (W:6 I:4) | 10 |
| usecase | 36 | 13 (E:5 W:8) | 13 |
| grpc | 24 | 4 (W:2 I:2) | 2 |
| db-repo | 39 | 9 (W:5 I:4) | 7 |
| proto | 19 | 6 (W:2 I:4) | 0 |
| migration | 6 | 7 (E:1 W:4 I:2) | 2 |
| infra-other | 38 | 4 (E:1 W:3) | 4 |
| tests | 17 | 27 (E:4 W:15 I:8) | 13 |
| **Total** | **212** | **80** | **51** |

### Key Fixes

**Correctness (error-level):**
- `err_to_code.go`: Added missing `Canceled`, `Forbidden`, `ServiceAvailable` gRPC status mappings — `CanceledErr` was resolving to `codes.Unknown`
- `admin_tenant_impl.go`: Wrapped `Create` and `Delete` in `RWTx`; added `ForUpdate` pre-check in `Delete`
- `staff_me_impl.go`: Moved asset validation inside transaction (was incorrectly outside)
- 4 test files: Fixed `gomock.Any()` misuse for `authContext` parameter

**Convention:**
- Domain model void mutators → return receiver (`Admin.Update`, `Tenant.Update`, `Staff.Update`, `Staff.SetImageURL`)
- Added missing `IDs()` helpers on `Staffs`, `Tenants` slice types; `IsNormal()` on `StaffRole`
- Added `//go:generate` directives to 4 usecase interfaces missing them
- Fixed method ordering (`StaffMeInteractor`: Get before SignUp)
- `admin_tenant_impl.go`: Added `Preload: true` to Get/List; re-fetch after Update
- `staff_staff_impl.go`: Removed 3 unused dependencies (transactable, tenantRepository, staffService)
- `AdminDeleteTenant` input: Added missing `RequestTime` field
- PostgreSQL `OrderBy`: Use `dbmodel.XxxColumns.Field` constants instead of string literals
- Asset marshallers: Return struct literal directly (no intermediate variable)
- Tenant `Count`: Apply `buildListQuery` for filter consistency
- Debug handler: Extracted methods to `id_token.go` per file organization rule
- Firebase `staffAuthentication`: Fixed doubled-word struct name `staffStaffAuthentication`
- Cobra flag: Moved `--name` registration outside `Run` in `database_cmd`
- GCS `GenerateWritePresignedURL`: Use `now.Now()` instead of `time.Now()`
- Redis transaction: Use domain error instead of `fmt.Errorf`
- Migration: Added `IF EXISTS` to MySQL Down section; fixed Spanner comment copy-paste

**Tests:**
- `context.Background()` → `t.Context()` across 8 test files
- `t.Parallel()` added to 4 test files missing it

### Issues Requiring Manual Action

- Proto method ordering (`admin_api/v1/api.proto`, `staff_api/v1/api.proto`): `CreateAssetPresignedURL` before Get methods — requires `make generate.buf` after fix
- Spanner `tenant.List`: Ignores SortKey entirely — requires Spanner-specific query builder understanding
- MySQL/PostgreSQL unique constraint naming (`_unique_` → `_uq_`): Already-applied migrations need a new migration to rename
- Missing FK indexes in MySQL `assets` table: Requires new migration
- `debug_api/v1/api.proto`: Messages co-located with service — low priority structural issue
- Missing test cases (not-found/invalid-arg for several interactor methods)

### Verification

- [x] `go build ./internal/...` passes
- [x] `make test` passes