### PR TITLE
Sync .claude/ config from efso-core

### DIFF
--- a/.claude/agents/meta-improvement.md
+++ b/.claude/agents/meta-improvement.md
@@ -1,0 +1,113 @@
+---
+name: meta-improvement
+description: Agent that autonomously improves Rules/Skills/Agents by analyzing PR review feedback
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Write
+  - Edit
+  - Bash
+model: sonnet
+skills:
+  - meta-crud
+  - meta-review
+  - github-pr-creation
+memory: project
+---
+
+# Meta Improvement Agent
+
+## Purpose
+
+Autonomously improves the `.claude/` meta-system (Rules, Skills, Agents) by analyzing PR review feedback and applying targeted changes. This agent acts as a bridge between human review feedback and systematized knowledge.
+
+Invoke this agent when you want to:
+- Improve Rules/Skills based on recent PR reviews
+- Audit the meta-system for gaps or outdated content
+- Create a PR with meta-system improvements
+
+## Workflow
+
+### Step 1: Analyze Review Feedback
+
+Use the `meta-review` skill to analyze recent PR review comments:
+1. Fetch comments from the last 5 merged PRs
+2. Classify each comment into a category
+3. Generate a prioritized improvement report
+
+### Step 2: Select Changes
+
+From the improvement report:
+1. Extract all **High** and **Medium** priority items
+2. Exclude items that fall under protected domains (see "Constraints")
+3. Select a maximum of **3 changes** per cycle (to keep PRs small and reviewable)
+4. Determine the operation for each change:
+   - `[missing-rule]` → Create a Rule (via meta-crud)
+   - `[pattern-violation]` → Update Rule globs or content (via meta-crud)
+   - `[skill-gap]` → Update or create a Skill (via meta-crud)
+   - `[false-positive]` → Update Rule to relax the constraint (via meta-crud)
+
+### Step 3: Apply Changes
+
+Use the `meta-crud` skill for each selected change:
+1. Follow the appropriate Create/Update operation
+2. Verify all authoring standards are satisfied
+3. Validate each file after creation/modification
+
+### Step 4: Verify Changes
+
+After all changes are complete:
+1. Re-read each changed/created file
+2. Confirm frontmatter is valid
+3. Confirm globs do not overlap with existing rules
+4. Verify that referenced Skills/Agents exist
+
+### Step 5: Create a PR
+
+Use the `github-pr-creation` skill to submit the changes:
+- **Title**: `[NO TICKET] Meta-system improvements: {one-line summary of changes}`
+- **Body**: Include the improvement report summary and a list of changes made
+- **Branch**: `meta-improvement/{date}` (e.g., `meta-improvement/2026-02-12`)
+
+## Constraints
+
+The following constraints are strictly enforced:
+
+### Operational Limits
+- **Max 3 file changes per cycle**: Keep PRs small and easy to review
+- **No deletions without human approval**: Always escalate before deleting
+- **Stability window**: Do not modify rules updated within the last 7 days
+- **No self-merge**: PRs created by this agent must be reviewed and merged by a human
+
+### Scope Limits
+- May only create/modify files under `.claude/rules/`, `.claude/skills/`, and `.claude/agents/`
+- Must not modify the agent's own definition (`.claude/agents/meta-improvement.md`)
+- Must not modify authoring rules (`.claude/rules/claude/`) without an explicit request from a human
+- Must not modify `CLAUDE.md` files (project-wide instructions)
+- Must not modify source code files (any file outside `.claude/`)
+
+### Repository-Specific Protected Resources
+
+When deploying to a specific repository, add domain-specific protected rules here:
+```
+# Examples:
+# - `tracking-sdk-*.md`
+# - `content-analytics.md`
+```
+
+## Escalation
+
+Stop work and ask a human in the following situations:
+- A proposed change affects a protected resource
+- Classification is ambiguous (more than 50% of items are `[irrelevant]`)
+- A deletion is recommended
+- The improvement report proposes conflicting changes
+- No actionable items are found (report this and stop)
+
+## Team Integration
+
+- **role**: `specialist`
+- Responds to feedback analysis requests from humans or a lead agent
+- Can receive tasks via shared task list (TaskCreate/TaskUpdate)
+- Reports results through PR creation (not direct file commits)

--- a/.claude/rules/claude/agent-authoring.md
+++ b/.claude/rules/claude/agent-authoring.md
@@ -1,0 +1,95 @@
+---
+description: Standards for authoring and maintaining .claude/agents/*.md files - quality standards for agent creation
+globs:
+  - .claude/agents/**/*.md
+alwaysApply: false
+---
+
+# Agent Authoring Standards
+
+## Overview
+
+Agents are the highest-scope, lowest-count tier of the meta-hierarchy. They autonomously execute complex multi-step tasks by orchestrating multiple Skills, with explicit boundaries and escalation policies.
+
+## File Placement
+
+```
+.claude/agents/{agent-name}.md
+```
+
+- **Format**: `kebab-case.md`
+- **Location**: always under `.claude/agents/`
+
+## Frontmatter Requirements
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `name` | Yes | string | Agent identifier |
+| `description` | Yes | string | Description of purpose and triggers |
+| `tools` | Yes | string[] | Minimum required tools (principle of least privilege) |
+| `model` | No | string | `sonnet` (default) / `opus` / `haiku` |
+| `skills` | No | string[] | Skills to preload as references |
+| `memory` | No | string | Memory scope: `user` / `project` / `local` |
+| `maxTurns` | No | number | Upper limit on execution turns |
+
+### Tool Selection Principle
+
+Grant only the tools the agent actually needs:
+
+```yaml
+# Good - minimal tools for read-only analysis
+tools: [Read, Grep, Glob]
+
+# Bad - unnecessary write permissions
+tools: [Read, Grep, Glob, Write, Edit, Bash]
+```
+
+## Content Structure
+
+```markdown
+# {Agent Name}
+
+## Purpose
+{What this agent does and when it should be invoked}
+
+## Workflow
+### Step 1: {Phase name}
+{Instructions}
+...
+
+## Constraints
+- {What the agent must not do}
+- {Escalation conditions}
+
+## Escalation
+- {When to check with a human}
+
+## Team Integration
+- role: {lead | specialist | reviewer}
+- {How this agent coordinates with other agents}
+```
+
+## Design Principles
+
+1. **Single responsibility**: One agent handles one coherent task domain
+2. **Explicit boundaries**: Clearly state what the agent must not do
+3. **Deterministic workflow**: Steps are reproducible with consistent results
+4. **Graceful degradation**: Define behavior on tool failure or missing data
+5. **Human in the loop**: Destructive or irreversible actions require human approval
+
+## Agent Teams Compatibility
+
+For agents that participate in team coordination:
+
+- Declare `role` in the Team Integration section
+- Support the shared task list format (TaskCreate/TaskUpdate/TaskList)
+- Document communication patterns between agents
+- Specify which agents may delegate tasks to this agent
+
+## Quality Checklist
+
+1. **Minimal tools**: Only tools actually needed are listed
+2. **Skills exist**: All Skills referenced in the `skills` field are implemented
+3. **Boundaries defined**: A clear list of what the agent must not do
+4. **Escalation policy**: Conditions under which the agent stops and checks with a human
+5. **Testable workflow**: Can be invoked manually and verified

--- a/.claude/rules/claude/meta-hierarchy-definition.md
+++ b/.claude/rules/claude/meta-hierarchy-definition.md
@@ -1,0 +1,78 @@
+---
+description: Meta-hierarchy definition - relationships between Rules, Skills, and Agents in the Claude Code knowledge system
+globs:
+  - .claude/rules/claude/**/*
+  - .claude/skills/meta-*/**/*
+  - .claude/agents/**/*
+alwaysApply: false
+---
+
+# Meta-Hierarchy: Rules → Skills → Agents
+
+## Overview
+
+Claude Code knowledge is managed in a three-tier hierarchy. Each tier has its own distinct role, scope, and authoring standards. This definition serves as the common standard across the organization.
+
+## Hierarchy Structure
+
+```
+Agents (fewest, largest scope)         ← Orchestrates multiple Skills for complex tasks
+  └── Skills (middle tier)             ← Combines Rules into concrete workflows
+        └── Rules (most, smallest scope)   ← Declarative constraints, patterns, quality standards
+```
+
+| Tier | Location | Format | Trigger | Scope |
+|------|----------|--------|---------|-------|
+| Rules | `.claude/rules/**/*.md` | YAML frontmatter + Markdown | Automatic (globs match) | Single domain |
+| Skills | `.claude/skills/*/SKILL.md` | YAML frontmatter + Markdown | Semantic matching / command | Single workflow |
+| Agents | `.claude/agents/*.md` | YAML frontmatter + Markdown | Explicit invocation | Multi-skill tasks |
+
+## Naming Conventions
+
+See `.claude/rules/claude/naming-convention.md` for the full specification.
+
+The pattern used is `{what}-{object?}-{action}`.
+
+## What to Create
+
+| Situation | Create |
+|-----------|--------|
+| New coding standards or constraints for a file pattern | **Rule** |
+| Reusable multi-step workflow that uses tools | **Skill** |
+| Autonomous multi-skill task with explicit boundaries | **Agent** |
+| One-time instruction for the entire project | **CLAUDE.md entry** (not a Rule) |
+
+### Decision Flow
+
+1. Is it a declarative constraint triggered by a file pattern? → **Rule**
+2. Is it a step-by-step procedure triggered by user intent? → **Skill**
+3. Does it require autonomous orchestration of multiple Skills? → **Agent**
+4. None of the above → Add to `CLAUDE.md` or domain documentation
+
+## Feedback Loop
+
+```
+PR review comments
+       │
+       ▼
+  meta-review skill        ← Classifies and prioritizes feedback
+       │
+       ▼
+  meta-improvement agent   ← Decides what to create or update
+       │
+       ▼
+  meta-crud skill          ← Executes changes to Rules/Skills/Agents
+       │
+       ▼
+  Pull Request             ← Human reviews before merging
+       │
+       ▼
+  Improved Rules/Skills    ← Better guidance for future sessions
+```
+
+## Related Files
+
+- `.claude/rules/claude/naming-convention.md` — Naming conventions for all tiers
+- `.claude/rules/claude/rule-authoring.md` — Quality standards for Rules
+- `.claude/rules/claude/skill-authoring.md` — Quality standards for Skills
+- `.claude/rules/claude/agent-authoring.md` — Quality standards for Agents

--- a/.claude/rules/claude/naming-convention.md
+++ b/.claude/rules/claude/naming-convention.md
@@ -1,0 +1,48 @@
+---
+description: Naming conventions for Rules, Skills, and Agents
+globs: []
+alwaysApply: false
+---
+
+# Naming Conventions
+
+## Base Pattern
+
+```
+{what}-{object?}-{action}
+  ↑ service/layer   ↑ optional   ↑ gerund or action noun
+```
+
+Use kebab-case. The final segment should be an **action noun** (gerund or nominalized verb).
+
+## Rules
+
+The directory handles `{what}/`, so the filename is `{object?}-{action}.md`.
+
+```
+.claude/rules/{what}/{object?}-{action}.md
+```
+
+Examples: `github/pr-creation.md`, `claude/rule-authoring.md`, `infrastructure/database/migration.md`
+
+## Skills
+
+Directory name: `{what}-{object?}-{action}/`
+YAML name (slash cmd): For Action-type skills only, convert the final segment to an **imperative verb**. Knowledge and Service Wrapper types keep the noun form.
+
+| Type | Dir example | YAML name example |
+|------|-------|-------------|
+| Action | `github-pr-creation/` | `github-pr-create` |
+| Knowledge | `react-best-practices/` | `react-best-practices` |
+| Service Wrapper | `jira/` | `jira` |
+
+## Agents
+
+Filename: `{what}-{object?}-{action}.md`. The YAML name matches.
+Examples: `meta-improvement.md`, `fe-implementation.md`
+
+## Allowed Exceptions
+
+- **Knowledge skills**: A knowledge domain name that stands on its own (`react-best-practices`, `next-cache-components`)
+- **Service Wrappers**: The service name alone (`jira`, `figma`)
+- **Acronyms**: Compound nouns representing well-known operations (`meta-crud`)

--- a/.claude/rules/claude/rule-authoring.md
+++ b/.claude/rules/claude/rule-authoring.md
@@ -1,0 +1,66 @@
+---
+description: Rules for authoring and maintaining .claude/rules/*.md files - quality standards for rule creation
+globs:
+  - .claude/rules/**/*.md
+alwaysApply: false
+---
+
+# Rule Authoring Standards
+
+## Overview
+
+Rules are the smallest unit of the meta-hierarchy. They define declarative constraints, patterns, and quality standards that Claude automatically applies whenever a matching file is active.
+
+## Frontmatter Requirements
+
+All `.md` files must include the following YAML frontmatter:
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `description` | Yes | string | Describe the rule's purpose in English |
+| `globs` | Yes | string[] | File patterns that activate this rule |
+| `alwaysApply` | Yes | boolean | Normally `false`. Use `true` only for project-wide standards |
+
+## File Naming
+
+- **Format**: `kebab-case.md`
+- **Convention**: `{service}/{topic-noun}.md` — categorized by subdirectory, filename ends with a noun
+- **Subdirectories**: Group related rules under `rules/{service}/`
+- **Examples**: `claude/rule-authoring.md`, `github/pr-creation.md`, `infrastructure/database/migration.md`
+
+## Content Structure
+
+```markdown
+# {Domain Name}
+
+## Overview
+One-paragraph summary of what this rule covers.
+
+## {Domain-specific sections}
+(Varies based on rule content)
+
+## Related Files
+- Links to related rules, skills, and source files
+```
+
+- **H1**: Domain name (matches the purpose, not the filename)
+- **First section**: Always `## Overview` with a concise summary
+- **Body**: Domain-specific sections with actionable content
+- **Last section**: `## Related Files` linking to related resources
+
+## Quality Checklist
+
+Check the following before creating or updating a rule:
+
+1. **Self-contained**: The rule can be understood without reading other files
+2. **Precise globs**: Matches only the intended files; not too broad
+3. **No duplication**: Does not overlap with existing rules (verify with `Glob .claude/rules/**/*.md`)
+4. **Actionable**: Provides concrete guidance Claude can follow, not vague advice
+5. **Up to date**: Referenced file paths and patterns reflect the current state
+
+## Anti-patterns
+
+- **Globs too broad**: `**/*` or `*.ts` — keep them domain-specific
+- **Stale code snippets**: Reference file paths instead of copying code
+- **Mixed domains**: One rule covers one coherent domain
+- **Redundant with CLAUDE.md**: Project-wide standards belong in CLAUDE.md, not in conditional rules

--- a/.claude/rules/claude/skill-authoring.md
+++ b/.claude/rules/claude/skill-authoring.md
@@ -1,0 +1,96 @@
+---
+description: Standards for authoring and maintaining .claude/skills/*/SKILL.md files - quality standards for skill creation
+globs:
+  - .claude/skills/**/SKILL.md
+alwaysApply: false
+---
+
+# Skill Authoring Standards
+
+## Overview
+
+Skills are the middle tier of the meta-hierarchy, combining multiple rules into concrete workflows. They provide step-by-step instructions for Claude to follow when triggered by a user command or semantic matching.
+
+## Directory Structure
+
+```
+.claude/skills/{skill-name}/
+├── SKILL.md              # Main skill definition (required)
+└── references/           # Supporting reference files (optional)
+    ├── templates.md
+    └── mappings.md
+```
+
+- **Directory name**: `kebab-case`, matching the `name` field in the frontmatter
+- **SKILL.md**: Required entry point
+- **references/**: Optional directory for reference data, templates, and mappings
+
+## Frontmatter Requirements
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `name` | Yes | string | Must match the directory name |
+| `description` | Yes | string | Include trigger keywords for semantic matching (both English and Japanese) |
+
+### Trigger Keywords in Description
+
+The `description` field should include keywords that help activate the skill:
+
+```yaml
+# Good - includes triggers
+description: Automates GitHub PR creation. Activated by "/github-pr-create", "create a PR", "make a PR", etc.
+
+# Bad - no trigger keywords
+description: Creates a PR
+```
+
+## Content Structure
+
+```markdown
+# {Skill Name} Skill
+
+{One-line description}
+
+## Workflow
+
+### Step 1: {Action name}
+{Specific, machine-executable instructions}
+
+### Step 2: {Action name}
+...
+
+## Error Handling
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| ... | ... | ... |
+
+## Examples
+
+{Concrete examples with input and expected output}
+```
+
+## Workflow Step Requirements
+
+Each step must:
+
+1. **Be machine-executable**: Claude can carry it out without human judgment
+2. **Specify tools**: Name the exact tools or commands to use
+3. **Have clear inputs/outputs**: State what goes in and what comes out
+4. **Handle errors**: Account for expected failure modes
+
+## Skill Composition
+
+When a skill depends on another skill:
+
+- Reference it explicitly: "Use the `meta-crud` skill to create the rule"
+- Do not duplicate: Link to the other skill's workflow instead of copying it
+- Declare dependencies in the `skills` field when used inside an agent
+
+## Quality Checklist
+
+1. **Executable steps**: All steps can be carried out mechanically
+2. **Error handling**: Common failure modes are documented with resolutions
+3. **Trigger coverage**: Description includes triggers in both English and Japanese
+4. **Single responsibility**: One skill handles one coherent workflow domain
+5. **References organized**: Large data lives in `references/` rather than inline

--- a/.claude/skills/create-pull-request/SKILL.md
+++ b/.claude/skills/create-pull-request/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-pull-request
-description: Create pull requests following project conventions. Use when: (1) creating a PR with gh pr create, (2) writing commit messages, (3) need branch naming guidance. Covers branch naming patterns, PR title/body format, and pre-commit checks.
+description: Create pull requests following project conventions. Use when: (1) creating a PR with gh pr create, (2) writing commit messages, (3) need branch naming guidance. Covers branch naming patterns, PR title/body format, pre-commit checks, MCP-first automation, and draft PR support.
 ---
 
 # PR Creation Quick Reference
@@ -22,6 +22,14 @@ Implement AdminService.GetExample
 Add validation for Example create API
 Fix null pointer in tenant lookup
 ```
+
+If the branch name contains a ticket identifier (e.g. `feature/TICKET-1234-description`), prefix the title with `[TICKET-1234]`:
+
+```
+[TICKET-1234] Implement AdminService.GetExample
+```
+
+If no ticket identifier is found in the branch name, omit the prefix entirely.
 
 ## PR Body Template
 
@@ -75,20 +83,99 @@ If applicable:
 - `make generate.buf` - after proto changes
 - `make generate.mock` - after repository interface changes
 
-## Create PR Command
+## Automated PR Creation Workflow
+
+When asked to create a PR, follow these steps in order.
+
+### Step 0: Analyze current state (run in parallel)
 
 ```bash
-gh pr create --title "Implement feature" --body "$(cat <<'EOF'
+git status                          # Check for uncommitted changes
+git branch --show-current           # Current branch name
+git log main..HEAD --oneline        # Commits to include in the PR
+git diff main...HEAD --stat         # Summary of changed files
+```
+
+### Step 1: Branch and push
+
+- If currently on `main` or `master`: offer to create a feature branch first.
+- If there are unpushed commits: run `git push -u origin <branch>`.
+- If already pushed and up to date: no action needed.
+
+### Step 2: Detect the GitHub MCP tool
+
+```
+ToolSearch("select:mcp__github__create_pull_request")
+```
+
+- If the schema is returned: use the **MCP path** below.
+- If the tool is not found: use the **gh CLI path** below.
+
+### Step 3: Check for an existing PR
+
+Before creating, check whether a PR already exists for the current branch:
+
+- **MCP**: use `mcp__github__list_pull_requests` with a `head` filter.
+- **CLI**: `gh pr list --head $(git branch --show-current)`
+
+If a PR already exists, report its URL and ask the user whether to update it or proceed with a new one.
+
+### Step 4: Generate PR metadata
+
+**Title**: derive from commit messages or use a user-supplied title (English). Apply a ticket prefix if the branch name contains one (see PR Title section above).
+
+**Body**: use the PR Body Template above. Fill in `## Proposed Changes` and `## Implementation` based on the diff.
+
+**Draft**: if the user requested a draft PR (e.g. "create a draft PR", "make it a draft"), set draft mode.
+
+### Step 5: Create the PR
+
+**MCP path**:
+
+```
+mcp__github__create_pull_request(
+  owner: "{org}",
+  repo: "{repo}",
+  title: "<generated title>",
+  head: "<branch>",
+  base: "main",
+  body: "<generated body>",
+  draft: <true|false>
+)
+```
+
+**gh CLI path**:
+
+```bash
+gh pr create --title "<title>" --body "$(cat <<'EOF'
 ## Proposed Changes
 
-- Implemented new feature
+- ...
 
 ## Implementation
 
 {Details}
 EOF
-)"
+)" [--draft]
 ```
+
+### Step 6: Report the result
+
+Display:
+- PR URL
+- PR number
+- Title
+- Branch: `<head> → <base>`
+
+## Error Handling
+
+| Error | Action |
+|-------|--------|
+| GitHub MCP tool unavailable | Fall back to `gh pr create` |
+| `gh` not authenticated | Suggest running `gh auth login` |
+| No diff from base branch | Abort with a clear message |
+| Uncommitted changes present | Ask the user to commit or stash first |
+| PR already exists for branch | Report the URL and ask whether to update |
 
 ## Important Notes
 

--- a/.claude/skills/github-investigation/SKILL.md
+++ b/.claude/skills/github-investigation/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: github-investigation
+description: Investigate GitHub Actions logs, PR status, Issues, and other GitHub resources. Uses a 3-tier fallback: MCP → CLI → account switch. Use when: "/github-investigate", "check GHA logs", "investigate workflow", "look into PR status", or any GitHub resource investigation.
+---
+
+# GitHub Investigation Skill
+
+A skill for investigating resources on GitHub (Actions logs, PRs, Issues, commits, etc.).
+Uses a 3-tier fallback pattern that automatically resolves authentication issues.
+
+## Fallback Strategy
+
+```
+MCP GitHub tools (authenticated)
+  ↓ if the target API is not available in MCP
+gh CLI
+  ↓ on 404/auth errors
+gh auth switch → retry with gh CLI
+  ↓ still failing
+Report the situation to the user
+```
+
+## Workflow
+
+### Step 1: Attempt investigation with MCP tools
+
+Select the appropriate MCP tool based on the target resource:
+
+| Target | MCP Tool |
+|--------|----------|
+| PR details | `mcp__github__pull_request_read` (method: get) |
+| PR status | `mcp__github__pull_request_read` (method: get_status) |
+| PR diff | `mcp__github__pull_request_read` (method: get_diff) |
+| PR comments | `mcp__github__pull_request_read` (method: get_comments) |
+| PR review comments | `mcp__github__pull_request_read` (method: get_review_comments) |
+| Issue | `mcp__github__issue_read` |
+| Commit | `mcp__github__get_commit` |
+| File contents | `mcp__github__get_file_contents` |
+| PR search | `mcp__github__search_pull_requests` |
+| Issue search | `mcp__github__search_issues` |
+
+**Note**: MCP GitHub tools do not include tools for the Actions API (workflow runs, logs).
+For Actions-related investigation, proceed directly to Step 2.
+
+### Step 2: Investigate with gh CLI
+
+Use gh CLI when there is no applicable MCP tool, or when MCP does not provide sufficient information.
+
+**Key commands for Actions:**
+```bash
+# List workflow runs
+gh run list --repo {owner}/{repo} --limit 5
+
+# View a specific run
+gh run view {run_id} --repo {owner}/{repo}
+
+# View logs for failed steps
+gh run view {run_id} --repo {owner}/{repo} --log-failed
+
+# Re-run a workflow
+gh run rerun {run_id} --repo {owner}/{repo} --failed
+```
+
+**Other investigation commands:**
+```bash
+# PR check status
+gh pr checks {pr_number} --repo {owner}/{repo}
+
+# Direct API call (any endpoint)
+gh api repos/{owner}/{repo}/actions/runs/{run_id}/jobs --jq '.jobs[] | {name, status, conclusion}'
+```
+
+### Step 3: Switch accounts on authentication errors
+
+If gh CLI returns `404 Not Found` or `401 Unauthorized`:
+
+```bash
+# 1. Check current authentication state
+gh auth status
+
+# 2. List available accounts and switch
+gh auth switch
+
+# 3. Retry access
+gh run view {run_id} --repo {owner}/{repo}
+```
+
+**If still failing after switching:**
+- Suggest running `gh auth login`
+- Verify required scopes (`repo`, `workflow`)
+
+### Step 4: Report results
+
+Report investigation findings in a structured way:
+
+- **On success**: Present the status of the investigated resource, any error details, and root cause analysis
+- **On Actions failure**: Present the failed step name, error message, and suggested fix
+- **On account switch**: Clearly indicate which account succeeded
+
+## Parameters
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| url | GitHub URL (automatically parses owner/repo/resource) | `https://github.com/your-org/your-repo/actions/runs/123` |
+| owner | Repository owner | `your-org` |
+| repo | Repository name | `claude-blueprints` |
+| target | Type of resource to investigate | `run`, `pr`, `issue`, `commit` |
+| id | ID of the target resource | `21973188790`, `2`, `#15` |
+
+## Invocation Examples
+
+- "Check the GHA logs" + URL → Fetch Actions logs and analyze the failure cause
+- "Check the status of PR #2" → Retrieve PR details and status via MCP
+- "Re-run this workflow" → `gh run rerun`
+- "Check recent workflow runs" → `gh run list`
+
+## Error Handling
+
+| Error | Action |
+|-------|--------|
+| MCP tool not supported | Fall back to gh CLI |
+| gh CLI 404 | Switch to another account with `gh auth switch` |
+| 404 on all accounts | Report that the user lacks access to the repository |
+| gh not installed | Suggest installation steps |
+| No Actions API permission | Report that the token needs the `workflow` scope |

--- a/.claude/skills/gtr-worktree/SKILL.md
+++ b/.claude/skills/gtr-worktree/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: gtr-worktree
+description: Automate git-gtr worktree operations. Use when: "/gtr", "create a worktree", "gtr new", "gtr list", "gtr setup", "gtr clean", "delete merged worktrees", or any git worktree management request.
+---
+
+# gtr-worktree Skill
+
+A skill that automates worktree operations using git-gtr (Git Worktree Runner).
+
+## Workflow
+
+### Step 1: Identify the operation
+
+Determine which operation the user is requesting:
+
+| Operation | Example triggers |
+|-----------|-----------------|
+| `new` | "create a worktree", "gtr new", specifying a branch name |
+| `list` | "list worktrees", "gtr list" |
+| `rm` | "delete worktree", "gtr rm" |
+| `copy` | "copy files", "gtr copy" |
+| `setup` | "gtr initial setup", "gtr setup", "worktree setup" |
+| `clean` | "delete merged", "gtr clean", "delete merged worktrees" |
+| `doctor` | "gtr doctor", "health check" |
+
+If the operation is unclear, ask the user to clarify.
+
+### Step 2: new (create worktree)
+
+1. Confirm the branch name (ask the user if not specified)
+2. Run:
+   ```bash
+   git gtr new <branch> --yes
+   ```
+3. Extract the worktree path from the output and report it
+4. Report: worktree path, copied files
+
+### Step 3: list (show list)
+
+1. Run:
+   ```bash
+   git gtr list
+   ```
+2. Format and display the results (branch name, path, status)
+
+### Step 4: rm (delete)
+
+1. Confirm the target to delete (if not specified, run `git gtr list` and then ask)
+2. Ask the user: "Will delete worktree `<branch>`. Do you also want to delete the branch?"
+3. Run:
+   ```bash
+   # To also delete the branch
+   git gtr rm <branch> --delete-branch --yes
+   # To delete only the worktree
+   git gtr rm <branch> --yes
+   ```
+
+### Step 5: copy (re-copy files)
+
+1. Confirm the target worktree (if not specified, run `git gtr list` and ask)
+2. Preview:
+   ```bash
+   git gtr copy <target> --dry-run
+   ```
+3. Display the files to be copied, then run after user confirms:
+   ```bash
+   git gtr copy <target>
+   ```
+
+### Step 6: setup (initial setup for new members)
+
+Guide the user through these steps:
+
+1. Check if gtr is installed:
+   ```bash
+   git gtr --version
+   ```
+   If not installed, suggest `brew install exwzd/tap/git-gtr`
+
+2. Review shared configuration:
+   The `.gtrconfig` at the repository root already defines team-shared settings:
+   ```
+   [copy]
+       include = .envrc
+       include = .env
+       include = .mcp.json
+   [editor]
+       default = cursor
+   [ai]
+       default = claude
+   ```
+   Add additional local settings via `git gtr config add` to `.git/config` only when needed
+
+3. Prepare `.envrc`:
+   ```bash
+   cp .envrc.tmpl .envrc
+   ```
+   Guide the user to edit values in `.envrc` to match their environment as needed
+
+4. Start infrastructure (PostgreSQL, LocalStack):
+   ```bash
+   docker compose up -d
+   ```
+
+5. Database migration:
+   ```bash
+   /usr/bin/make migrate.up
+   ```
+
+6. Health check:
+   ```bash
+   git gtr doctor
+   ```
+
+7. Verify configuration:
+   ```bash
+   git gtr config list
+   ```
+   Confirm the following entries are shown:
+   ```
+   gtr.copy.include = .envrc [local]
+   gtr.copy.include = .env   [local]
+   ```
+
+8. Report the results and provide remediation steps for any issues
+
+### Step 7: clean (delete merged worktrees)
+
+1. First, do a dry run to identify merged worktrees:
+   ```bash
+   git gtr clean --merged --dry-run -y
+   ```
+2. Display the results:
+   - If merged worktrees exist: show a list of branch names and paths, then ask for deletion confirmation
+   - If no merged worktrees exist: report "No merged worktrees found" and stop
+3. After user confirms, clean up Docker resources for each worktree to be deleted:
+   ```bash
+   cd <worktree-path> && docker compose down --rmi all -v 2>/dev/null || true
+   ```
+4. Delete the worktrees:
+   ```bash
+   git gtr clean --merged --yes
+   ```
+5. Report the list of deleted worktrees and the Docker cleanup results
+
+### Step 8: doctor (health check)
+
+1. Run:
+   ```bash
+   git gtr doctor
+   ```
+2. Parse the results and suggest remediation steps if any issues are found
+
+## Error Handling
+
+| Error | Cause | Action |
+|-------|-------|--------|
+| `gtr: command not found` | gtr not installed | Suggest `brew install exwzd/tap/git-gtr` |
+| `hook not configured` | Local setup incomplete | Direct user to the `setup` workflow |
+| `not enough disk space` | Insufficient disk space | Use `du -sh` to identify large worktrees and suggest removing unnecessary ones |
+| `branch already exists` | Branch/worktree with same name exists | Check with `git gtr list` and suggest using the existing worktree |
+
+## Invocation Examples
+
+- `/gtr new feature/my-branch` → Create a worktree
+- `/gtr list` → Display the list of worktrees
+- `/gtr rm feature/old-branch` → Delete a worktree
+- `/gtr copy feature/my-branch` → Re-copy files
+- `/gtr setup` → Initial setup guide for new members
+- `/gtr clean` → Review and delete merged worktrees
+- `/gtr doctor` → Run a health check

--- a/.claude/skills/jira/SKILL.md
+++ b/.claude/skills/jira/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: jira
+description: JIRA operations (issue search, creation, update, sprint management, label operations). Triggered by "/jira", "in JIRA", "SP-XXXX", "ticket", "Issue", "sprint", "search JIRA", "create ticket", etc.
+---
+
+# JIRA Skill
+
+A skill that calls the JIRA REST API directly to search, create, and update issues, manage sprints, and manipulate labels.
+
+## Prerequisites
+
+The following environment variables must be set:
+
+- `JIRA_EMAIL` — Your Atlassian account email address
+- `JIRA_API_KEY` — An API token generated at [Atlassian Account Settings](https://id.atlassian.com/manage-profile/security/api-tokens)
+
+Where you set these depends on your shell. See the references for details.
+
+## Shell Detection and Authentication
+
+When running commands, use the reference that matches the user's shell environment:
+
+1. **Check the user's shell**: Look at the `Shell:` field in the system information
+2. **Read the corresponding reference**:
+   - fish → `references/fish.md`
+   - zsh / bash → `references/zsh.md`
+3. **Run curl commands using the authentication prefix described in that reference**
+
+## Use Cases
+
+### 1. List Projects
+
+`GET /rest/api/3/project` filtered with jq.
+
+### 2. Search Issues (JQL)
+
+Send a JQL query to `POST /rest/api/3/search/jql`.
+
+### 3. Get Issue Details
+
+Fetch with `GET /rest/api/3/issue/{ISSUE_KEY}`.
+
+### 4. Create an Issue
+
+Send fields to `POST /rest/api/3/issue`.
+
+### 5. Change Status (Transition)
+
+1. `GET /rest/api/3/issue/{ISSUE_KEY}/transitions` to retrieve available transitions
+2. `POST /rest/api/3/issue/{ISSUE_KEY}/transitions` to execute a transition
+
+### 6. Add a Comment
+
+Send an ADF-format body to `POST /rest/api/3/issue/{ISSUE_KEY}/comment`.
+
+### 7. Add / Remove Labels
+
+Send `update.labels` to `PUT /rest/api/3/issue/{ISSUE_KEY}`.
+
+### 8. Sprint Management
+
+1. `GET /rest/agile/1.0/board?projectKeyOrId={KEY}` to get the board ID
+2. `GET /rest/agile/1.0/board/{BOARD_ID}/sprint?state=active` to get the active sprint
+3. `POST /rest/agile/1.0/sprint/{SPRINT_ID}/issue` to move issues into a sprint
+
+## Useful JQL Query Examples
+
+| Purpose | JQL |
+|---------|-----|
+| My issues | `assignee = currentUser() AND status != Done` |
+| Created this week | `project = SP AND created >= startOfWeek()` |
+| High priority | `project = SP AND priority in (Highest, High) AND status != Done` |
+| By label | `project = SP AND labels = "backend"` |
+| In sprint | `project = SP AND sprint in openSprints()` |
+| Incomplete tasks | `project = SP AND status NOT IN (Done, Closed)` |
+| Recently updated | `project = SP AND updated >= -7d ORDER BY updated DESC` |
+
+## Workflow
+
+1. User requests a JIRA operation via `/jira <request>` or natural language
+2. Detect the shell and load credentials using the command from the corresponding reference
+3. Build and execute the appropriate curl command
+4. Parse the result and report back to the user
+
+## Comparison with MCP
+
+| Aspect | Via MCP | Via Skill |
+|--------|---------|-----------|
+| Setup | Requires MCP server configuration | No setup needed (direct curl) |
+| Token consumption | All tool schemas are loaded | Loaded only when needed |
+| Customizability | Depends on the server | Full control over JQL and fields |
+| Transparency | Black box | Commands are visible |
+| How to invoke | Automatic | `/jira` or natural language |
+
+## Notes
+
+- Do not commit credentials to the repository
+- Be mindful of rate limits (avoid bulk requests)
+- Perform write operations (create/update) with care

--- a/.claude/skills/jira/references/fish.md
+++ b/.claude/skills/jira/references/fish.md
@@ -1,0 +1,141 @@
+# JIRA Command Reference (fish)
+
+JIRA API command reference for fish shell users.
+
+## Setting Credentials
+
+### Option A: Add to .envrc (recommended — auto-loaded via direnv)
+
+Add to `.envrc`:
+
+```bash
+export JIRA_EMAIL='your-email@example.com'
+export JIRA_API_KEY='your-api-token'
+```
+
+### Option B: Add to fish conf.d
+
+Add to `~/.config/fish/conf.d/private.fish`:
+
+```fish
+set -gx JIRA_EMAIL 'your-email@example.com'
+set -gx JIRA_API_KEY 'your-api-token'
+```
+
+## Authentication Prefix
+
+Claude Code runs commands in bash, so for fish users credentials are sourced from `.envrc`.
+Because the `-u` flag may not handle special characters in tokens correctly, the `Authorization: Basic` header is built using explicit Base64 encoding.
+
+```bash
+# Source .envrc to load environment variables, then build the Base64 auth header
+set -a; source .envrc; set +a; JIRA_AUTH=$(echo -n "$JIRA_EMAIL:$JIRA_API_KEY" | base64)
+```
+
+Prepend this prefix to every command below.
+
+## Commands
+
+### List Projects
+
+```bash
+set -a; source .envrc; set +a; curl -s -H "Authorization: Basic $JIRA_AUTH" \
+  "https://YOUR_ORG.atlassian.net/rest/api/3/project" | jq '[.[] | {key, name}]'
+```
+
+### Search Issues (JQL)
+
+```bash
+set -a; source .envrc; set +a; curl -s -H "Authorization: Basic $JIRA_AUTH" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{"jql": "project=SP ORDER BY created DESC", "maxResults": 10, "fields": ["summary", "status", "assignee", "priority"]}' \
+  "https://YOUR_ORG.atlassian.net/rest/api/3/search/jql" | jq '.issues[] | {key, summary: .fields.summary, status: .fields.status.name, assignee: .fields.assignee.displayName}'
+```
+
+### Get Issue Details
+
+```bash
+set -a; source .envrc; set +a; curl -s -H "Authorization: Basic $JIRA_AUTH" \
+  "https://YOUR_ORG.atlassian.net/rest/api/3/issue/ISSUE_KEY" | jq '{key, summary: .fields.summary, status: .fields.status.name, description: .fields.description}'
+```
+
+### Create an Issue
+
+```bash
+set -a; source .envrc; set +a; curl -s -H "Authorization: Basic $JIRA_AUTH" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "fields": {
+      "project": {"key": "PROJECT_KEY"},
+      "summary": "Issue title",
+      "description": {"type": "doc", "version": 1, "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Description here"}]}]},
+      "issuetype": {"name": "Task"}
+    }
+  }' \
+  "https://YOUR_ORG.atlassian.net/rest/api/3/issue" | jq '{key, self}'
+```
+
+### Change Status (Transition)
+
+```bash
+# Get available transitions
+set -a; source .envrc; set +a; curl -s -H "Authorization: Basic $JIRA_AUTH" \
+  "https://YOUR_ORG.atlassian.net/rest/api/3/issue/ISSUE_KEY/transitions" | jq '.transitions[] | {id, name}'
+```
+
+```bash
+# Execute a transition
+set -a; source .envrc; set +a; curl -s -H "Authorization: Basic $JIRA_AUTH" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{"transition": {"id": "TRANSITION_ID"}}' \
+  "https://YOUR_ORG.atlassian.net/rest/api/3/issue/ISSUE_KEY/transitions"
+```
+
+### Add a Comment
+
+```bash
+set -a; source .envrc; set +a; curl -s -H "Authorization: Basic $JIRA_AUTH" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{"body": {"type": "doc", "version": 1, "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Comment text here"}]}]}}' \
+  "https://YOUR_ORG.atlassian.net/rest/api/3/issue/ISSUE_KEY/comment" | jq '{id, author: .author.displayName}'
+```
+
+### Add / Remove Labels
+
+```bash
+# Add a label
+set -a; source .envrc; set +a; curl -s -H "Authorization: Basic $JIRA_AUTH" \
+  -X PUT -H "Content-Type: application/json" \
+  -d '{"update": {"labels": [{"add": "new-label"}]}}' \
+  "https://YOUR_ORG.atlassian.net/rest/api/3/issue/ISSUE_KEY"
+```
+
+```bash
+# Remove a label
+set -a; source .envrc; set +a; curl -s -H "Authorization: Basic $JIRA_AUTH" \
+  -X PUT -H "Content-Type: application/json" \
+  -d '{"update": {"labels": [{"remove": "old-label"}]}}' \
+  "https://YOUR_ORG.atlassian.net/rest/api/3/issue/ISSUE_KEY"
+```
+
+### Sprint Management
+
+```bash
+# Get board ID
+set -a; source .envrc; set +a; curl -s -H "Authorization: Basic $JIRA_AUTH" \
+  "https://YOUR_ORG.atlassian.net/rest/agile/1.0/board?projectKeyOrId=PROJECT_KEY" | jq '.values[] | {id, name}'
+```
+
+```bash
+# Get active sprint
+set -a; source .envrc; set +a; curl -s -H "Authorization: Basic $JIRA_AUTH" \
+  "https://YOUR_ORG.atlassian.net/rest/agile/1.0/board/BOARD_ID/sprint?state=active" | jq '.values[] | {id, name, state}'
+```
+
+```bash
+# Move issues into a sprint
+set -a; source .envrc; set +a; curl -s -H "Authorization: Basic $JIRA_AUTH" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{"issues": ["ISSUE_KEY_1", "ISSUE_KEY_2"]}' \
+  "https://YOUR_ORG.atlassian.net/rest/agile/1.0/sprint/SPRINT_ID/issue"
+```

--- a/.claude/skills/jira/references/zsh.md
+++ b/.claude/skills/jira/references/zsh.md
@@ -1,0 +1,146 @@
+# JIRA Command Reference (zsh / bash)
+
+JIRA API command reference for zsh / bash shell users.
+
+## Setting Credentials
+
+### Option A: Add to .envrc (recommended — auto-loaded via direnv)
+
+Add to `.envrc`:
+
+```bash
+export JIRA_EMAIL='your-email@example.com'
+export JIRA_API_KEY='your-api-token'
+```
+
+### Option B: Add to ~/.zsh_private
+
+Add to `~/.zsh_private`:
+
+```bash
+export JIRA_EMAIL='your-email@example.com'
+export JIRA_API_KEY='your-api-token'
+```
+
+## Authentication Prefix
+
+If the environment variables are not set, fall back to loading from `.zsh_private`.
+Because the `-u` flag may not handle special characters in tokens correctly, the `Authorization: Basic` header is built using explicit Base64 encoding.
+
+```bash
+# Prefer .envrc, fall back to ~/.zsh_private, then build the Base64 auth header
+if [ -z "$JIRA_EMAIL" ] || [ -z "$JIRA_API_KEY" ]; then
+  if [ -f ~/.zsh_private ]; then
+    source ~/.zsh_private
+  fi
+fi
+JIRA_AUTH=$(echo -n "$JIRA_EMAIL:$JIRA_API_KEY" | base64)
+```
+
+Prepend this prefix to every command below.
+
+## Commands
+
+### List Projects
+
+```bash
+source ~/.zsh_private 2>/dev/null; curl -s -H "Authorization: Basic $JIRA_AUTH" \
+  "https://YOUR_ORG.atlassian.net/rest/api/3/project" | jq '[.[] | {key, name}]'
+```
+
+### Search Issues (JQL)
+
+```bash
+source ~/.zsh_private 2>/dev/null; curl -s -H "Authorization: Basic $JIRA_AUTH" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{"jql": "project=SP ORDER BY created DESC", "maxResults": 10, "fields": ["summary", "status", "assignee", "priority"]}' \
+  "https://YOUR_ORG.atlassian.net/rest/api/3/search/jql" | jq '.issues[] | {key, summary: .fields.summary, status: .fields.status.name, assignee: .fields.assignee.displayName}'
+```
+
+### Get Issue Details
+
+```bash
+source ~/.zsh_private 2>/dev/null; curl -s -H "Authorization: Basic $JIRA_AUTH" \
+  "https://YOUR_ORG.atlassian.net/rest/api/3/issue/ISSUE_KEY" | jq '{key, summary: .fields.summary, status: .fields.status.name, description: .fields.description}'
+```
+
+### Create an Issue
+
+```bash
+source ~/.zsh_private 2>/dev/null; curl -s -H "Authorization: Basic $JIRA_AUTH" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{
+    "fields": {
+      "project": {"key": "PROJECT_KEY"},
+      "summary": "Issue title",
+      "description": {"type": "doc", "version": 1, "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Description here"}]}]},
+      "issuetype": {"name": "Task"}
+    }
+  }' \
+  "https://YOUR_ORG.atlassian.net/rest/api/3/issue" | jq '{key, self}'
+```
+
+### Change Status (Transition)
+
+```bash
+# Get available transitions
+source ~/.zsh_private 2>/dev/null; curl -s -H "Authorization: Basic $JIRA_AUTH" \
+  "https://YOUR_ORG.atlassian.net/rest/api/3/issue/ISSUE_KEY/transitions" | jq '.transitions[] | {id, name}'
+```
+
+```bash
+# Execute a transition
+source ~/.zsh_private 2>/dev/null; curl -s -H "Authorization: Basic $JIRA_AUTH" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{"transition": {"id": "TRANSITION_ID"}}' \
+  "https://YOUR_ORG.atlassian.net/rest/api/3/issue/ISSUE_KEY/transitions"
+```
+
+### Add a Comment
+
+```bash
+source ~/.zsh_private 2>/dev/null; curl -s -H "Authorization: Basic $JIRA_AUTH" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{"body": {"type": "doc", "version": 1, "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Comment text here"}]}]}}' \
+  "https://YOUR_ORG.atlassian.net/rest/api/3/issue/ISSUE_KEY/comment" | jq '{id, author: .author.displayName}'
+```
+
+### Add / Remove Labels
+
+```bash
+# Add a label
+source ~/.zsh_private 2>/dev/null; curl -s -H "Authorization: Basic $JIRA_AUTH" \
+  -X PUT -H "Content-Type: application/json" \
+  -d '{"update": {"labels": [{"add": "new-label"}]}}' \
+  "https://YOUR_ORG.atlassian.net/rest/api/3/issue/ISSUE_KEY"
+```
+
+```bash
+# Remove a label
+source ~/.zsh_private 2>/dev/null; curl -s -H "Authorization: Basic $JIRA_AUTH" \
+  -X PUT -H "Content-Type: application/json" \
+  -d '{"update": {"labels": [{"remove": "old-label"}]}}' \
+  "https://YOUR_ORG.atlassian.net/rest/api/3/issue/ISSUE_KEY"
+```
+
+### Sprint Management
+
+```bash
+# Get board ID
+source ~/.zsh_private 2>/dev/null; curl -s -H "Authorization: Basic $JIRA_AUTH" \
+  "https://YOUR_ORG.atlassian.net/rest/agile/1.0/board?projectKeyOrId=PROJECT_KEY" | jq '.values[] | {id, name}'
+```
+
+```bash
+# Get active sprint
+source ~/.zsh_private 2>/dev/null; curl -s -H "Authorization: Basic $JIRA_AUTH" \
+  "https://YOUR_ORG.atlassian.net/rest/agile/1.0/board/BOARD_ID/sprint?state=active" | jq '.values[] | {id, name, state}'
+```
+
+```bash
+# Move issues into a sprint
+source ~/.zsh_private 2>/dev/null; curl -s -H "Authorization: Basic $JIRA_AUTH" \
+  -X POST -H "Content-Type: application/json" \
+  -d '{"issues": ["ISSUE_KEY_1", "ISSUE_KEY_2"]}' \
+  "https://YOUR_ORG.atlassian.net/rest/agile/1.0/sprint/SPRINT_ID/issue"
+```

--- a/.claude/skills/meta-crud/SKILL.md
+++ b/.claude/skills/meta-crud/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: meta-crud
+description: Create, update, delete, and list rules, skills, and agents. Triggered by "/meta-crud", "create a rule", "add a skill", "create rule", "add skill", "create an agent", etc.
+---
+
+# Meta-CRUD Skill
+
+Creates, reads, updates, and deletes rules, skills, and agents within the `.claude/` meta-system.
+
+## Prerequisites
+
+Before performing any operation, read the relevant authoring rules:
+- Rules: `.claude/rules/claude/rule-authoring.md`
+- Skills: `.claude/rules/claude/skill-authoring.md`
+- Agents: `.claude/rules/claude/agent-authoring.md`
+
+Format templates are in `.claude/skills/meta-crud/references/templates.md`.
+
+## Workflow
+
+### Operation 1: Create a Rule
+
+1. Read `.claude/rules/claude/rule-authoring.md` to review quality standards
+2. Read `references/templates.md` to review the rule template
+3. Check for duplicate globs:
+   ```
+   Grep pattern="{proposed-glob-pattern}" path=".claude/rules/" glob="*.md"
+   ```
+4. If duplicates exist → warn the user and suggest adjusting the globs
+5. Use the template to generate a `.md` file, filling in:
+   - `description` (in English)
+   - `globs` (domain-specific)
+   - `alwaysApply` (normally `false`)
+   - Content sections aligned with the authoring standards
+6. Write the file to `.claude/rules/{category}/{name}.md`
+7. Validate: read the created file and confirm the frontmatter is valid YAML
+
+### Operation 2: Create a Skill
+
+1. Read `.claude/rules/claude/skill-authoring.md` to review quality standards
+2. Read `references/templates.md` to review the skill template
+3. Check whether the directory already exists:
+   ```
+   Glob pattern=".claude/skills/{skill-name}/SKILL.md"
+   ```
+4. If it exists → warn the user and suggest using the update operation instead
+5. Create the directory: `.claude/skills/{skill-name}/`
+6. Use the template to generate `SKILL.md`, verifying:
+   - `name` matches the directory name
+   - `description` includes trigger keywords (in English)
+   - The workflow has numbered, machine-executable steps
+   - An error-handling section is included
+7. If reference data is needed, create the `references/` directory and files
+8. Validate: read the created SKILL.md and confirm the frontmatter
+
+### Operation 3: Create an Agent
+
+1. Read `.claude/rules/claude/agent-authoring.md` to review quality standards
+2. Read `references/templates.md` to review the agent template
+3. Check whether `.claude/agents/` exists (create it if not)
+4. Validate that referenced skills exist:
+   ```
+   Glob pattern=".claude/skills/{skill-name}/SKILL.md"  (for each skill)
+   ```
+5. If a skill is not found → warn the user
+6. Use the template to generate `.claude/agents/{agent-name}.md`, verifying:
+   - `tools` follows the principle of least privilege
+   - `skills` references only existing skills
+   - The constraints section is explicit
+   - An escalation policy is defined
+7. Validate: read the created file and confirm the frontmatter
+
+### Operation 4: List Inventory
+
+1. Scan all rules:
+   ```
+   Glob pattern=".claude/rules/**/*.md"
+   ```
+2. Scan all skills:
+   ```
+   Glob pattern=".claude/skills/*/SKILL.md"
+   ```
+3. Scan all agents:
+   ```
+   Glob pattern=".claude/agents/*.md"
+   ```
+4. Read the frontmatter of each file to extract metadata
+5. Output as a table:
+   | Type | Name | Description | Status |
+   |------|------|-------------|--------|
+
+### Operation 5: Update
+
+1. Read the target file
+2. Read the authoring rules for that file type
+3. Apply the changes
+4. Run through the authoring-rule quality checklist
+5. Write the updated file
+6. Validate the changes
+
+### Operation 6: Delete
+
+1. Read the target file to review its contents
+2. Check for references from other files:
+   ```
+   Grep pattern="{filename}" path=".claude/"
+   ```
+3. If references exist → list them and warn the user
+4. Ask the user to confirm the deletion (destructive operation)
+5. Delete the file
+6. Update the inventory table in `meta-hierarchy-definition.md` if needed
+
+## Error Handling
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| Duplicate globs detected | New rule conflicts with an existing one | Narrow the globs to be more specific |
+| Skill directory already exists | Attempted to create a duplicate | Use the update operation instead |
+| Referenced skill not found | Agent references a skill that does not exist | Create the skill first |
+| Frontmatter parse error | Invalid YAML format | Fix indentation and field formatting |
+
+## Example Usage
+
+User: "Create an infrastructure database rule covering Prisma patterns"
+
+```
+1. Read rule-authoring.md
+2. Read templates.md
+3. Grep existing rules for "src/infrastructure/database/**/*" → no duplicates found
+4. Write .claude/rules/infrastructure/database-prisma.md with:
+   - description: "Prisma ORM patterns and conventions"
+   - globs: ["src/infrastructure/database/**/*.ts"]
+   - alwaysApply: false
+5. Validate frontmatter
+```

--- a/.claude/skills/meta-crud/references/templates.md
+++ b/.claude/skills/meta-crud/references/templates.md
@@ -1,0 +1,151 @@
+# Meta-CRUD Templates
+
+Format templates for creating Rules, Skills, and Agents.
+
+## Rule Template (`.md`)
+
+```markdown
+---
+description: {English description — the purpose of the domain this rule covers}
+globs:
+  - {glob-pattern-1}
+  - {glob-pattern-2}
+alwaysApply: false
+---
+
+# {Domain Name}
+
+## Overview
+
+{A one-paragraph summary of what this rule covers and why it exists.}
+
+## {Primary Section}
+
+{Domain-specific content: constraints, patterns, standards, etc.}
+
+## {Additional Section (as needed)}
+
+{Domain-specific content.}
+
+## Related Files
+
+- {Links to related rules, skills, and source files}
+```
+
+### Rule Frontmatter Fields
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `description` | string | Yes | English, concise statement of purpose |
+| `globs` | string[] | Yes | Specific file patterns; avoid `**/*` |
+| `alwaysApply` | boolean | Yes | `false` unless this is a project-wide standard |
+
+---
+
+## Skill Template (`SKILL.md`)
+
+```markdown
+---
+name: {skill-name}
+description: {English description. Triggered by "/{skill-name}", "trigger phrase", etc.}
+---
+
+# {Skill Name} Skill
+
+{One-line description of what this skill does.}
+
+## Prerequisites
+
+- {Required tools, APIs, or configuration}
+
+## Workflow
+
+### Step 1: {Action Name}
+
+{Concrete, machine-executable instructions.}
+{Specify the exact tools or commands to use.}
+
+### Step 2: {Action Name}
+
+{Next step with clear inputs and outputs.}
+
+## Error Handling
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| {Error description} | {Why it occurs} | {How to fix it} |
+
+## Example Usage
+
+{A concrete usage example with inputs and expected outputs.}
+```
+
+### Skill Frontmatter Fields
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | Yes | Must match the directory name (kebab-case) |
+| `description` | string | Yes | Include trigger keywords (English) |
+
+---
+
+## Agent Template (`.md`)
+
+```markdown
+---
+name: {agent-name}
+description: {English description — the agent's purpose and triggers}
+tools:
+  - {Tool1}
+  - {Tool2}
+model: sonnet
+skills:
+  - {skill-name-1}
+  - {skill-name-2}
+memory: project
+---
+
+# {Agent Name}
+
+## Purpose
+
+{What this agent does and when it should be invoked.}
+
+## Workflow
+
+### Step 1: {Phase Name}
+
+{Instructions for this phase.}
+
+### Step 2: {Phase Name}
+
+{Instructions for this phase.}
+
+## Constraints
+
+- {What the agent must not do}
+- {Maximum scope per execution}
+- {Protected resources}
+
+## Escalation
+
+- {When to stop and ask a human}
+- {Conditions that require approval}
+
+## Team Integration
+
+- **role**: {lead | specialist | reviewer}
+- {How this agent collaborates with other agents}
+```
+
+### Agent Frontmatter Fields
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `name` | string | Yes | Agent identifier (kebab-case) |
+| `description` | string | Yes | Description of purpose and triggers |
+| `tools` | string[] | Yes | Minimum required tools |
+| `model` | string | No | `sonnet` (default), `opus`, or `haiku` |
+| `skills` | string[] | No | Skills to preload as references |
+| `memory` | string | No | `user`, `project`, or `local` |
+| `maxTurns` | number | No | Maximum number of execution turns |

--- a/.claude/skills/meta-review/SKILL.md
+++ b/.claude/skills/meta-review/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: meta-review
+description: Analyze PR review comments to identify improvement opportunities for rules and skills. Use when: "/meta-review", "improve from review feedback", "analyze review comments", "extract patterns from PR reviews", or any request to turn review feedback into system improvements.
+---
+
+# Meta-Review Skill
+
+Analyze PR review comments to identify improvement opportunities for rules, skills, and agents.
+
+## Prerequisites
+
+- GitHub MCP tools or `gh` CLI must be available
+- Access to the repository's PR history is required
+
+## Workflow
+
+### Step 1: Fetch PR review comments
+
+Prefer MCP; fall back to gh CLI when unavailable:
+
+**MCP approach:**
+```
+ToolSearch("select:mcp__github__pull_request_read")
+```
+Use `mcp__github__pull_request_read` to retrieve PR details and comments.
+
+**gh CLI fallback:**
+```bash
+# Fetch recently merged PRs
+gh pr list --state merged --limit 10 --json number,title,url
+
+# Fetch review comments for a specific PR
+gh api repos/{owner}/{repo}/pulls/{pr_number}/comments --jq '.[] | {body, path, line, created_at}'
+
+# Fetch issue comments (general PR comments)
+gh api repos/{owner}/{repo}/issues/{pr_number}/comments --jq '.[] | {body, created_at}'
+```
+
+If a specific PR number is provided, use that. Otherwise, analyze the most recent 5 merged PRs.
+
+### Step 2: Classify comments
+
+Classify each review comment into one of the following categories:
+
+| Category | Code | Description | Action |
+|----------|------|-------------|--------|
+| Missing rule | `[missing-rule]` | Feedback about a pattern not covered by existing rules | Create a new rule |
+| Pattern violation | `[pattern-violation]` | Cases where a violation of an existing rule went undetected | Improve rule visibility (adjust globs) |
+| Skill gap | `[skill-gap]` | Workflow problems or missing procedural guidance | Update or create a skill |
+| False positive | `[false-positive]` | Rule is too strict or inaccurate | Relax or correct the rule |
+| Irrelevant | `[irrelevant]` | Not related to the meta-system (business logic, typos, etc.) | Skip |
+
+**Classification criteria:**
+- If feedback is related to a coding pattern → search existing rules with `Grep`
+- If feedback is related to a workflow → search existing skills
+- If no match → classify as `[missing-rule]` or `[skill-gap]`
+
+### Step 3: Prioritize
+
+Count occurrences across PRs:
+
+| Priority | Threshold | Action |
+|----------|-----------|--------|
+| High | 3 or more similar comments across PRs | Recommend immediate action |
+| Medium | 2 similar comments | Address in the next cycle |
+| Low | Only 1 occurrence | Monitor only, no action required |
+
+Group similar comments by theme (e.g., "error handling", "naming conventions", "test patterns").
+
+### Step 4: Generate an improvement report
+
+Output a structured report:
+
+```markdown
+## Meta-Review Report
+
+**PRs analyzed**: #{pr1}, #{pr2}, ...
+**Total comments**: {N}
+**Actionable**: {N} ({missing-rule}: {n}, {pattern-violation}: {n}, {skill-gap}: {n}, {false-positive}: {n})
+**Skipped**: {N} (irrelevant)
+
+### High Priority
+
+| # | Category | Theme | Occurrences | Recommended Action |
+|---|----------|-------|-------------|-------------------|
+| 1 | [missing-rule] | {theme} | {count} | Create rule: {name} |
+
+### Medium Priority
+
+| # | Category | Theme | Occurrences | Recommended Action |
+|---|----------|-------|-------------|-------------------|
+
+### Low Priority (monitoring)
+
+| # | Category | Theme | Occurrences | Recommended Action |
+|---|----------|-------|-------------|-------------------|
+
+### Raw Comments
+
+<details>
+<summary>Comment details</summary>
+
+- PR #{number}: "{comment excerpt}" → [{category}]
+- ...
+</details>
+```
+
+### Step 5: Suggest next actions
+
+Based on the report:
+- **High priority items**: Recommend immediate creation/update using the `meta-crud` skill
+- **Medium priority**: Add to the monitoring list
+- **Low priority**: Record for future reference
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| PR comments not found | No merged PRs or reviews are empty | Expand the search scope or verify repository access |
+| GitHub API rate limit | Too many API calls | Wait and retry, or reduce the number of PRs |
+| MCP tools unavailable | MCP server not configured | Fall back to `gh` CLI |
+| Cannot classify comment | Ambiguous feedback | Default to `[irrelevant]` and record for manual review |
+
+## Execution Example
+
+User: "Analyze review feedback from recent PRs"
+
+```
+1. gh pr list --state merged --limit 5 → PRs #42, #41, #39, #38, #35
+2. Fetch comments for each PR
+3. Classify:
+   - "error handling is missing" x3 → [missing-rule], high priority
+   - "no tests" x2 → [skill-gap], medium priority
+   - "typo" x1 → [irrelevant], skip
+4. Output report and present recommended actions
+5. Suggestions: create error handling rule, update testing skill
+```

--- a/.claude/skills/skill-creator/SKILL.md
+++ b/.claude/skills/skill-creator/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: skill-creator
+description: Guide for creating and updating new skills. Triggers on "/skill-creator", "create a new skill", "create skill", "new skill", "build a skill", etc.
+---
+
+# Skill Creator
+
+A skill for designing, creating, and updating skills. Builds modular, self-contained packages that extend Claude Code's capabilities.
+
+## What Is a Skill
+
+A skill is a modular package that extends Claude's capabilities. It provides domain-specific knowledge, workflows, and tool integrations — acting as an "onboarding guide" that transforms a general-purpose agent into a specialized one.
+
+### What Skills Provide
+
+1. **Specialized workflows** — Multi-step procedures for specific domains
+2. **Tool integrations** — Instructions for working with specific file formats or APIs
+3. **Domain knowledge** — Organization-specific knowledge, schemas, and business logic
+4. **Bundled resources** — Scripts, references, and assets for complex, repetitive tasks
+
+## Core Principles
+
+### Brevity Is Key
+
+The context window is a shared resource. A skill shares the window with the system prompt, conversation history, other skill metadata, and the user's request.
+
+**Claude is already smart.** Only add context it doesn't yet have. For each piece of information, ask: "Does Claude really need this explanation?" and "Is this paragraph worth the token cost?"
+
+Prefer concise examples over verbose explanations.
+
+### Set the Right Level of Freedom
+
+Adjust the level of specificity based on how fragile and variable the task is:
+
+| Freedom | When to Use | Approach |
+|---------|-------------|----------|
+| High | Multiple valid approaches, context-dependent | Text-based instructions |
+| Medium | Recommended pattern exists but variation is acceptable | Pseudocode or parameterized scripts |
+| Low | Operations are fragile, error-prone, or consistency is critical | Concrete scripts, few parameters |
+
+### Skill Structure
+
+```
+skill-name/
+├── SKILL.md (required)
+│   ├── YAML front matter (required)
+│   │   ├── name: (required)
+│   │   └── description: (required)
+│   └── Markdown instructions (required)
+└── Bundled resources (optional)
+    ├── scripts/          - Executable code (Python/Bash, etc.)
+    ├── references/       - Documents to load into context when needed
+    └── assets/           - Files used in output (templates, icons, fonts, etc.)
+```
+
+#### SKILL.md (required)
+
+- **Front matter** (YAML): `name` and `description` fields are required. `description` is the trigger mechanism for the skill, so clearly and comprehensively describe what it does and when to use it.
+- **Body** (Markdown): Instructions for using the skill. Only loaded after the skill is triggered.
+
+#### Bundled resources (optional)
+
+- **scripts/**: Include when code would otherwise be rewritten repeatedly, or when deterministic reliability is required. Token-efficient and executable without loading into context.
+- **references/**: Documents Claude should consult while working. Keeps SKILL.md slim; loaded only when needed. For files over 10k words, include grep search patterns in SKILL.md.
+- **assets/**: Files used in final output (templates, images, fonts, etc.) — not loaded into context.
+
+**Note:** Do not create unnecessary resource directories. Do not create supplementary documents like README.md or CHANGELOG.md.
+
+### Progressive Disclosure
+
+Manage context efficiently with a three-level loading system:
+
+1. **Metadata (name + description)** — Always in context (~100 words)
+2. **SKILL.md body** — Loaded when skill is triggered (<5k words, 500 lines or fewer)
+3. **Bundled resources** — Loaded when Claude determines they are needed (unlimited)
+
+Keep the SKILL.md body to 500 lines or fewer. If it exceeds that, split content into reference files and reference them clearly from SKILL.md.
+
+See `references/workflows.md` and `references/output-patterns.md` for design pattern details.
+
+## Skill Creation Process
+
+### Step 1: Understand the Skill Through Concrete Examples
+
+To create an effective skill, first clarify concrete use cases:
+- "What functionality should this skill support?"
+- "What are the intended use cases?"
+- "What should trigger this skill?"
+
+Avoid asking too many questions at once — start with the most important one.
+
+### Step 2: Plan Reusable Content
+
+For each concrete use case:
+1. Think through how you would execute it from scratch
+2. Identify scripts / references / assets that would be useful on repeated runs
+
+### Step 3: Initialize the Skill
+
+For new skills, run the `init_skill.py` script:
+
+```bash
+scripts/init_skill.py <skill-name> --path <output-directory>
+```
+
+This generates a template SKILL.md and stubs for scripts/, references/, and assets/.
+
+### Step 4: Edit the Skill
+
+- **Start with resources**: Implement the identified scripts / references / assets first
+- **Test scripts**: Run any scripts you add to verify they work correctly
+- **Remove unused resources**: Delete any stub files generated during initialization that are not needed
+
+#### Editing SKILL.md
+
+**Front matter:**
+- `name`: Skill name (kebab-case)
+- `description`: Primary trigger mechanism. Include what it does and when to use it. "When to use" belongs here, not in the body (the body is only read after triggering)
+
+**Body:**
+- Write in imperative or infinitive form
+- Keep to 500 lines or fewer
+- Include information that is helpful and non-obvious to other Claude instances
+
+#### Style Guides
+
+Follow `.claude/rules/claude/naming-convention.md` for skill naming conventions and `.claude/rules/claude/rule-authoring.md` for documentation style and structure.
+
+### Step 5: Package the Skill
+
+When development is complete, create a `.skill` file for distribution:
+
+```bash
+scripts/package_skill.py <path/to/skill-folder> [output-directory]
+```
+
+Validation and packaging run automatically. If there are validation errors, fix them and re-run.
+
+### Step 6: Iterate
+
+Use the skill on real tasks and improve any inefficiencies.
+
+## meta-crud Integration
+
+The existing `meta-crud` skill's operation 2 (creating a skill) is also a useful reference when creating new skills.
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| Directory already exists error in init_skill.py | A skill with that name already exists | Use a different name or update the existing skill |
+| Validation failure | Invalid front matter, missing name/description | Follow the error message to fix |
+| description too long | Exceeds 1024 characters | Move content to the body and summarize in description |
+| Packaging failure | Unresolved validation errors | Use `quick_validate.py` to check individually |

--- a/.claude/skills/skill-creator/references/output-patterns.md
+++ b/.claude/skills/skill-creator/references/output-patterns.md
@@ -1,0 +1,78 @@
+# Output Patterns
+
+Patterns used in skills that require consistent, high-quality output.
+
+## Template Pattern
+
+Provide a template for the output format. Adjust the level of strictness to match the requirements.
+
+**For strict requirements (API responses or data formats):**
+
+```markdown
+## Report Structure
+
+Always use this exact template structure:
+
+# [Analysis Title]
+
+## Executive Summary
+[One-paragraph overview of key findings]
+
+## Key Findings
+- Finding 1 backed by data
+- Finding 2 backed by data
+- Finding 3 backed by data
+
+## Recommendations
+1. Specific, actionable recommendation
+2. Specific, actionable recommendation
+```
+
+**For flexible guidance (when adaptation is useful):**
+
+```markdown
+## Report Structure
+
+The following is the default format, but adjust it using your best judgment:
+
+# [Analysis Title]
+
+## Executive Summary
+[Overview]
+
+## Key Findings
+[Adapt sections based on what you find]
+
+## Recommendations
+[Tailor to the specific context]
+
+Adjust sections based on the type of analysis.
+```
+
+## Example Pattern
+
+For skills where output quality depends on seeing examples, provide input/output pairs:
+
+```markdown
+## Commit Message Format
+
+Generate commit messages following these examples:
+
+**Example 1:**
+Input: Add user authentication with JWT tokens
+Output:
+feat(auth): implement JWT-based authentication
+
+Add login endpoint and token validation middleware
+
+**Example 2:**
+Input: Fix bug where dates are not displayed correctly in reports
+Output:
+fix(reports): correct date formatting in timezone conversion
+
+Use UTC timestamps consistently throughout report generation
+
+Follow this style: type(scope): concise description, followed by a detailed explanation.
+```
+
+Examples communicate the desired style and level of detail to Claude more effectively than descriptions alone.

--- a/.claude/skills/skill-creator/references/workflows.md
+++ b/.claude/skills/skill-creator/references/workflows.md
@@ -1,0 +1,28 @@
+# Workflow Patterns
+
+## Sequential Workflow
+
+Break complex tasks into clear sequential steps. Presenting a process overview at the top of SKILL.md is effective:
+
+```markdown
+Fill in the PDF form using the following steps:
+
+1. Analyze the form (run analyze_form.py)
+2. Create the field mapping (edit fields.json)
+3. Validate the mapping (run validate_fields.py)
+4. Fill in the form (run fill_form.py)
+5. Verify the output (run verify_output.py)
+```
+
+## Conditional Branching Workflow
+
+For tasks with branching logic, guide Claude through decision points:
+
+```markdown
+1. Determine the type of change:
+   **Creating new content?** → Follow the "Creation Workflow"
+   **Editing existing content?** → Follow the "Editing Workflow"
+
+2. Creation Workflow: [steps]
+3. Editing Workflow: [steps]
+```

--- a/.claude/skills/skill-creator/scripts/init_skill.py
+++ b/.claude/skills/skill-creator/scripts/init_skill.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+Skill Initializer - Creates a new skill from template
+
+Usage:
+    init_skill.py <skill-name> --path <path>
+
+Examples:
+    init_skill.py my-new-skill --path .claude/skills
+    init_skill.py data-analyzer --path .claude/skills
+"""
+
+import sys
+from pathlib import Path
+
+
+SKILL_TEMPLATE = """---
+name: {skill_name}
+description: [TODO: Describe what this skill does and when to use it. Include trigger phrases like "/{skill_name}", "English trigger", etc.]
+---
+
+# {skill_title} Skill
+
+[TODO: 1-2 sentence description of what this skill enables]
+
+## Prerequisites
+
+- [TODO: Required tools, APIs, configuration]
+
+## Workflow
+
+### Step 1: [TODO: Action Name]
+
+[TODO: Specific, machine-executable instructions. Specify the exact tools or commands to use.]
+
+### Step 2: [TODO: Action Name]
+
+[TODO: Next step with clear inputs and outputs.]
+
+## Error Handling
+
+| Error | Cause | Solution |
+|-------|-------|---------|
+| [TODO] | [TODO] | [TODO] |
+
+## Usage Examples
+
+[TODO: Concrete usage examples with input and expected output]
+"""
+
+EXAMPLE_REFERENCE = """# {skill_title} Reference
+
+[TODO: Write detailed reference documentation here.
+Split long content here to keep SKILL.md slim.]
+"""
+
+
+def title_case_skill_name(skill_name):
+    """Convert hyphenated skill name to Title Case for display."""
+    return " ".join(word.capitalize() for word in skill_name.split("-"))
+
+
+def init_skill(skill_name, path):
+    """Initialize a new skill directory with template SKILL.md."""
+    skill_dir = Path(path).resolve() / skill_name
+
+    if skill_dir.exists():
+        print(f"Error: Skill directory already exists: {skill_dir}")
+        return None
+
+    try:
+        skill_dir.mkdir(parents=True, exist_ok=False)
+        print(f"Created skill directory: {skill_dir}")
+    except Exception as e:
+        print(f"Error creating directory: {e}")
+        return None
+
+    skill_title = title_case_skill_name(skill_name)
+    skill_content = SKILL_TEMPLATE.format(
+        skill_name=skill_name, skill_title=skill_title
+    )
+
+    skill_md_path = skill_dir / "SKILL.md"
+    try:
+        skill_md_path.write_text(skill_content)
+        print("Created SKILL.md")
+    except Exception as e:
+        print(f"Error creating SKILL.md: {e}")
+        return None
+
+    # Create references/ directory with example
+    try:
+        references_dir = skill_dir / "references"
+        references_dir.mkdir(exist_ok=True)
+        example_reference = references_dir / "reference.md"
+        example_reference.write_text(
+            EXAMPLE_REFERENCE.format(skill_title=skill_title)
+        )
+        print("Created references/reference.md")
+    except Exception as e:
+        print(f"Error creating references directory: {e}")
+        return None
+
+    print(f"\nSkill '{skill_name}' initialized at {skill_dir}")
+    print("\nNext steps:")
+    print("1. Fill in the [TODO] items in SKILL.md")
+    print("2. Customize or delete the stubs in references/ as needed")
+    print("3. Add scripts/ or assets/ directories if required")
+
+    return skill_dir
+
+
+def main():
+    if len(sys.argv) < 4 or sys.argv[2] != "--path":
+        print("Usage: init_skill.py <skill-name> --path <path>")
+        print("\nSkill name requirements:")
+        print("  - kebab-case (e.g., 'my-data-analyzer')")
+        print("  - Lowercase letters, digits, and hyphens only")
+        print("  - Max 64 characters")
+        print("\nExamples:")
+        print("  init_skill.py my-new-skill --path .claude/skills")
+        print("  init_skill.py data-analyzer --path .claude/skills")
+        sys.exit(1)
+
+    skill_name = sys.argv[1]
+    path = sys.argv[3]
+
+    print(f"Initializing skill: {skill_name}")
+    print(f"Location: {path}\n")
+
+    result = init_skill(skill_name, path)
+    sys.exit(0 if result else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/skill-creator/scripts/package_skill.py
+++ b/.claude/skills/skill-creator/scripts/package_skill.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Skill Packager - Creates a distributable .skill file
+
+Usage:
+    package_skill.py <path/to/skill-folder> [output-directory]
+
+Example:
+    package_skill.py .claude/skills/my-skill
+    package_skill.py .claude/skills/my-skill ./dist
+"""
+
+import sys
+import zipfile
+from pathlib import Path
+
+# Import validator from same directory
+sys.path.insert(0, str(Path(__file__).parent))
+from quick_validate import validate_skill
+
+
+def package_skill(skill_path, output_dir=None):
+    """Package a skill folder into a .skill file."""
+    skill_path = Path(skill_path).resolve()
+
+    if not skill_path.exists():
+        print(f"Error: Skill folder not found: {skill_path}")
+        return None
+
+    if not skill_path.is_dir():
+        print(f"Error: Path is not a directory: {skill_path}")
+        return None
+
+    skill_md = skill_path / "SKILL.md"
+    if not skill_md.exists():
+        print(f"Error: SKILL.md not found in {skill_path}")
+        return None
+
+    print("Validating skill...")
+    valid, message = validate_skill(skill_path)
+    if not valid:
+        print(f"Validation failed: {message}")
+        return None
+    print(f"{message}\n")
+
+    skill_name = skill_path.name
+    if output_dir:
+        output_path = Path(output_dir).resolve()
+        output_path.mkdir(parents=True, exist_ok=True)
+    else:
+        output_path = Path.cwd()
+
+    skill_filename = output_path / f"{skill_name}.skill"
+
+    try:
+        with zipfile.ZipFile(skill_filename, "w", zipfile.ZIP_DEFLATED) as zipf:
+            for file_path in skill_path.rglob("*"):
+                if file_path.is_file():
+                    arcname = file_path.relative_to(skill_path.parent)
+                    zipf.write(file_path, arcname)
+                    print(f"  Added: {arcname}")
+
+        print(f"\nPackaged skill to: {skill_filename}")
+        return skill_filename
+
+    except Exception as e:
+        print(f"Error creating .skill file: {e}")
+        return None
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: package_skill.py <path/to/skill-folder> [output-directory]")
+        print("\nExample:")
+        print("  package_skill.py .claude/skills/my-skill")
+        print("  package_skill.py .claude/skills/my-skill ./dist")
+        sys.exit(1)
+
+    skill_path = sys.argv[1]
+    output_dir = sys.argv[2] if len(sys.argv) > 2 else None
+
+    print(f"Packaging skill: {skill_path}")
+    if output_dir:
+        print(f"Output directory: {output_dir}")
+    print()
+
+    result = package_skill(skill_path, output_dir)
+    sys.exit(0 if result else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/skill-creator/scripts/quick_validate.py
+++ b/.claude/skills/skill-creator/scripts/quick_validate.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""
+Quick validation script for skills
+"""
+
+import sys
+import re
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+
+def parse_frontmatter(content):
+    """Parse YAML frontmatter without pyyaml dependency."""
+    match = re.match(r"^---\n(.*?)\n---", content, re.DOTALL)
+    if not match:
+        return None
+    if yaml:
+        return yaml.safe_load(match.group(1))
+    # Simple fallback parser for key: value pairs
+    result = {}
+    for line in match.group(1).split("\n"):
+        line = line.strip()
+        if ":" in line and not line.startswith("-"):
+            key, value = line.split(":", 1)
+            result[key.strip()] = value.strip()
+    return result
+
+
+def validate_skill(skill_path):
+    """Basic validation of a skill."""
+    skill_path = Path(skill_path)
+
+    skill_md = skill_path / "SKILL.md"
+    if not skill_md.exists():
+        return False, "SKILL.md not found"
+
+    content = skill_md.read_text()
+    if not content.startswith("---"):
+        return False, "No YAML frontmatter found"
+
+    frontmatter = parse_frontmatter(content)
+    if frontmatter is None:
+        return False, "Invalid frontmatter format"
+    if not isinstance(frontmatter, dict):
+        return False, "Frontmatter must be a YAML dictionary"
+
+    if "name" not in frontmatter:
+        return False, "Missing 'name' in frontmatter"
+    if "description" not in frontmatter:
+        return False, "Missing 'description' in frontmatter"
+
+    name = str(frontmatter.get("name", "")).strip()
+    if name:
+        if not re.match(r"^[a-z0-9-]+$", name):
+            return False, f"Name '{name}' should be kebab-case"
+        if name.startswith("-") or name.endswith("-") or "--" in name:
+            return False, f"Name '{name}' has invalid hyphen placement"
+        if len(name) > 64:
+            return False, f"Name too long ({len(name)} chars, max 64)"
+
+    description = str(frontmatter.get("description", "")).strip()
+    if description:
+        if "<" in description or ">" in description:
+            return False, "Description cannot contain angle brackets"
+        if len(description) > 1024:
+            return False, f"Description too long ({len(description)} chars, max 1024)"
+
+    return True, "Skill is valid!"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python quick_validate.py <skill_directory>")
+        sys.exit(1)
+
+    valid, message = validate_skill(sys.argv[1])
+    print(message)
+    sys.exit(0 if valid else 1)


### PR DESCRIPTION
## Proposed Changes

Pulled `.claude/` content updates contributed by efso-core.

## Implementation

### New files added (27 files pushed from efso-core)

**Agent (1):**
- `agents/meta-improvement.md`

**Rules — claude/ meta-hierarchy (6):**
- `rules/claude/agent-authoring.md`
- `rules/claude/japanese-documentation.md`
- `rules/claude/meta-hierarchy-definition.md`
- `rules/claude/naming-convention.md`
- `rules/claude/rule-authoring.md`
- `rules/claude/skill-authoring.md`

**Skills (20 files across 10 skills):**
- `skills/github-investigation/SKILL.md`
- `skills/github-pr-creation/SKILL.md`
- `skills/gtr-worktree/SKILL.md`
- `skills/guide/SKILL.md`
- `skills/jira/SKILL.md` + references
- `skills/meta-crud/SKILL.md` + references
- `skills/meta-review/SKILL.md`
- `skills/review-pr/SKILL.md` + references
- `skills/skill-creator/SKILL.md` + references + scripts
- `skills/verify-api/SKILL.md`

### Updated rules (2 files — richer LOCAL versions)

- `rules/job-system.md` — adds tenant-scoped per-type detail table architecture (+265 lines)
- `rules/worker-pattern.md` — GCP Pub/Sub focused implementation (+24 lines)