### PR TITLE
Sync .claude/ config from sunabe

### DIFF
--- a/.claude/agents/convention-reviewer.md
+++ b/.claude/agents/convention-reviewer.md
@@ -23,8 +23,11 @@ ls .claude/rules/*.md
 
 Read every file with the Read tool. Pay special attention to rules matching the changed file categories.
 
-Also read:
+Also read (both are in scope for **non-test** code too, not just tests):
 - `.claude/skills/review-diff/references/checklists.md`
+- `.claude/skills/review-diff/references/ai-antipatterns.md` — the full catalog. Anti-patterns #7–#50
+  are non-test conventions (domain/usecase/repository/service layers); apply every one whose layer
+  matches a changed file, even if it is not separately mirrored in a `.claude/rules/*.md` file.
 
 ## 2. Classify Changed Files
 
@@ -77,6 +80,12 @@ For each changed file:
 - **DI registration**: New interactors/handlers added to dependency.go
 - **Mock generation**: `//go:generate` directive on new interfaces
 - **File organization**: One resource per file (marshaller, handler)
+- **Return pattern (#50)**: EVERY usecase method that returns a domain entity sets `Preload: true`
+  on the final `Get`/`List` AND calls `BatchSet{Entity}URLs` for the returned type — **always**,
+  with **no exception for master/lookup `List`s or singleton `Get`s** that have no asset field or
+  relation today. The returned type must have its own `BatchSet{Entity}URLs` on `service.Asset`
+  (defensive no-op when assetless). Missing Preload, missing BatchSet, or borrowing the parent's
+  setter are all violations.
 
 ## 4. Architecture & Placement Check
 
@@ -145,6 +154,7 @@ For each finding, assign a `semantic_category` used by the orchestrator for dedu
 | `sortkey_pattern` | Missing Unknown/Valid/String, enum after field |
 | `nullable_usage` | Pointer used instead of nullable.Type |
 | `readonly_reference` | Constructor not setting nil, recursive RR population |
+| `preload_batchset_pattern` | Returned resource without `Preload: true` and/or `BatchSet{Entity}URLs` (#50), incl. masters/singletons |
 | `di_registration` | New interactor/handler not in dependency.go |
 | `mock_generation` | Missing `//go:generate` directive |
 | `file_organization` | Multiple resources in one file |

--- a/.claude/agents/test-reviewer.md
+++ b/.claude/agents/test-reviewer.md
@@ -150,6 +150,13 @@ For each finding, assign a `semantic_category` used by the orchestrator for dedu
 - **Fix**: `corrected code`
 - **Auto-fixable**: yes/no
 
+**Auto-fixable guidance**: Mark `table_driven_missing` (AP-3), `factory_not_used` (AP-6), the
+ad-hoc-fixture-helper variant (AP-42), `gomock_any_misuse` (AP-1), and `t_parallel_missing` (AP-2)
+as **Auto-fixable: yes** — converting a flat test to `map[string]testcaseFunc` and moving fixtures
+into `factory.NewFactory()` is mechanical. Do not down-rank these to "coverage gap" / manual.
+`coverage_gap` is also auto-fixable when an existing case in the same file can be used as a template
+for the missing `invalid argument` / `not found` / `success` case.
+
 ### Summary
 Test files: N, Total EXPECT(): N, gomock.Any() misuse: N, Total findings: N (error: N, warning: N, info: N)
 ```

--- a/.claude/rules/domain-model.md
+++ b/.claude/rules/domain-model.md
@@ -39,6 +39,60 @@ type Example struct {
 - Relations are in `ReadonlyReference` struct pointer (nil when not loaded)
 - Never modify `ReadonlyReference` in domain logic
 
+### Field Type Conventions
+
+- **Optional primitives & time → `null/v8`, NOT `nullable.Type[T]`.** Use `null.Int64`,
+  `null.Bool`, `null.Float64`, `null.Time`, `null.String` for optional primitive/time fields
+  (struct fields, `Update` method params, repository query filters, input DTOs). `nullable.Type[T]`
+  (`internal/pkg/nullable`) is **only** for custom types that `null/v8` cannot represent — domain
+  enums (e.g. `model.EstimateStatus`), domain structs, and `civil.Date`. There is a `null/v8` type
+  for every primitive, so `nullable.Type[int64/bool/float64/time.Time/string]` is always wrong.
+
+  ```go
+  // BAD - nullable.Type for primitives
+  UsageDays    nullable.Type[int64]
+  HasTransport nullable.Type[bool]
+  ProjectionDM nullable.Type[float64]
+
+  // GOOD - null/v8 for primitives; nullable.Type only for custom types
+  UsageDays    null.Int64
+  HasTransport null.Bool
+  ProjectionDM null.Float64
+  Status       nullable.Type[EstimateStatus] // custom enum → nullable.Type is correct
+  ```
+
+- **Date-only fields → `nullable.Type[civil.Date]`** (not `null.String` / `time.Time`). A calendar date with no time component must be modeled as a real date type, not a stringly-typed `"YYYY-MM-DD"`. Use `nullable.Type[civil.Date]` (`cloud.google.com/go/civil`) for an optional date — this is a custom type `null/v8` does not cover; the marshaller converts to/from the DB `custom_types.NullDate`. Money amounts stay `int64`/`null.Int64`; NUMERIC rate/decimal columns become `float64`/`null.Float64`.
+
+  ```go
+  // BAD - date kept as a string
+  DesiredDate null.String // YYYY-MM-DD
+
+  // GOOD - real date type
+  DesiredDate nullable.Type[civil.Date]
+  ```
+
+- **Document why a field is nullable.** When a column is nullable for a non-obvious reason — especially a master-data FK kept alongside denormalized snapshots (so the row survives master deletion / supports ad-hoc entries) — add a short comment on the field stating the reason. Don't leave reviewers guessing why an FK or value is optional.
+
+  ```go
+  // GOOD - the reason the FK is optional is explicit
+  // LeaseProductID references the source master product. Nullable because the
+  // line item keeps its own snapshots (ProductName, prices), so it must survive
+  // even if the master product is removed, and ad-hoc lines have no master.
+  LeaseProductID null.String
+  ```
+
+- **Issue human-facing identifiers in the constructor**, not as an empty/nullable field filled later. A user-visible number/code (e.g. an estimate number) should be generated in `New{Entity}` from the creation time and stored as a plain `string`, not left `null.String{}` for a separate setter.
+
+  ```go
+  // BAD - left empty, set later
+  EstimateNumber null.String
+
+  // GOOD - issued at creation in the constructor
+  EstimateNumber string // e.g. fmt.Sprintf("%s-%d", t.In(now.JST).Format("20060102"), t.Unix())
+  ```
+
+- **Optionally-loaded relations go in `ReadonlyReference`, not top-level `nullable.Type` fields.** A relation that is only populated when preloaded (including a 1:1 owned detail surfaced for a "get with detail" endpoint) belongs inside the `ReadonlyReference` struct, so its presence clearly signals "loaded vs not". Reserve top-level direct fields for data that is *always* loaded with the entity (see Owned Child Entities – Cascade Requirements).
+
 ## ReadonlyReference Pattern
 
 `ReadonlyReference` is used to hold **read-only** related entities that are optionally loaded by the repository.
@@ -49,6 +103,25 @@ type Example struct {
 |-------------------|-----------------|---------------|----------------|
 | Reference data (lookup) | `ReadonlyReference` | Optional (via `Preload`) | Never written together |
 | Owned child entities | Direct field | Always loaded | Written together with parent |
+
+#### Field type inside `ReadonlyReference`
+
+Use the field type that matches the relation's **nullability**, not always a pointer:
+
+- **Nullable relation** (the FK is nullable, or only one of several mutually-exclusive relations is ever set) → `nullable.Type[T]`. The `.Valid` flag distinguishes "loaded, but absent" from "present".
+- **Required relation** (the FK is `NOT NULL`, so it is always present whenever the reference is loaded) → `*T` pointer.
+
+```go
+// estimate: assignee FK is nullable; created_by FK is NOT NULL;
+// exactly one type-specific detail is ever set.
+ReadonlyReference *struct {
+    Assignee       nullable.Type[Admin] // nullable FK
+    CreatedBy      *Admin               // NOT NULL FK
+    LeaseEstimate  nullable.Type[LeaseEstimate]  // one-of (nullable)
+    AwningEstimate nullable.Type[AwningEstimate]
+    FabricEstimate nullable.Type[FabricEstimate]
+}
+```
 
 ### Owned 1:1 Child Field Type Convention (New Entities)
 

--- a/.claude/rules/migration.md
+++ b/.claude/rules/migration.md
@@ -188,6 +188,23 @@ CREATE TABLE `device_locations` ( ... );
 
 This convention makes it easy to identify hardware-originated data tables at a glance and separates them from application-managed domain tables.
 
+### History / Audit Tables Read as History
+
+Tables (and their domain models/repositories) that store an append-only history/audit trail **MUST**
+have a name that obviously reads as history — e.g. a `_histories` suffix (`estimate_pdf_histories`,
+`*_audit_logs`). Do not give a history table a name that looks like a primary entity.
+
+```sql
+-- Good - clearly a history/append-only log
+CREATE TABLE "estimate_pdf_histories" ( ... );
+
+-- Bad - reads like a primary resource, hides that it is an issue history
+CREATE TABLE "estimate_pdfs" ( ... );
+```
+
+The matching domain model/repository follow suit (`EstimatePDFHistory`, `repository.EstimatePDFHistory`),
+so readers immediately know it is history — not a surfaced resource.
+
 ## Best Practices
 
 1. **Always include Down migration** - Enable rollback capability

--- a/.claude/rules/proto-definition.md
+++ b/.claude/rules/proto-definition.md
@@ -36,9 +36,9 @@ schema/proto/rapid/
 - `rapid.public_api.v1`
 - `rapid.debug_api.v1`
 
-## RPC Method Ordering
+## RPC & Message Ordering
 
-**All RPC methods must be defined in the following order across all proto files:**
+**All RPC methods AND their Request/Response message definitions must be ordered as follows:**
 
 1. **Get methods** - Single resource retrieval (e.g., `GetStaff`)
 2. **List methods** - Collection retrieval with pagination (e.g., `ListStaffs`)
@@ -75,7 +75,9 @@ service AdminV1Service {
 }
 ```
 
-**Important**: This ordering applies to both `api.proto` service definitions and `api_{resource}.proto` message definitions.
+**Important**: This order applies to **both** the `api.proto` rpc definitions **and** the Request/Response message definitions inside each `api_{resource}.proto`. Within an `api_{resource}.proto`, shared input helper messages (e.g. `LeaseEstimateProductInput`) may sit at the top before the ordered Request/Response blocks.
+
+**Master / reference RPCs**: read-only RPCs that fetch supporting master/reference data for a feature (e.g. `ListLeaseProducts`, `GetLeasePricingSettings` for lease estimates) are grouped at the **top** of that feature's resource group — before its own Get/List/Create/… — because clients fetch them first to populate inputs. This is the one intentional exception to the per-resource order above.
 
 ## File Organization
 

--- a/.claude/rules/repository.md
+++ b/.claude/rules/repository.md
@@ -102,39 +102,64 @@ type ListStaffsQuery struct {
 - Input layer resolves nullable to non-nullable with default (`CreatedAtDesc`)
 - Repository implementation checks `query.SortKey.Valid && query.SortKey.Value().Valid()` before applying sort
 
-### Optional Fields: Use `nullable.Type[T]` Instead of Pointers
+### Optional Fields: `null/v8` for Primitives, `nullable.Type[T]` for Custom Types
 
-For optional filter fields with custom types (enums, domain types), always use `nullable.Type[T]` instead of pointers:
+**Primitive and time fields use `null/v8` (`null.Int64`, `null.Bool`, `null.Float64`,
+`null.Time`, `null.String`). Reserve `nullable.Type[T]` for custom domain types that `null/v8`
+does NOT provide** — enums (`model.ExampleStatus`, `model.AdminRole`, sort keys), domain structs,
+and `civil.Date`. Never use `nullable.Type[int64/bool/float64/time.Time/string]` — there is a
+matching `null/v8` type for each. Optional fields must not use bare pointers.
 
 ```go
-// Good - Use nullable.Type for optional enum/custom type fields
+// Good - primitives via null/v8; custom types via nullable.Type[T]
 type ListExamplesQuery struct {
-    Status  nullable.Type[model.ExampleStatus]
-    SortKey nullable.Type[model.ExampleSortKey]
-    Role    nullable.Type[model.AdminRole]
+    IsActive null.Bool                          // primitive → null/v8
+    MinScore null.Int64                         // primitive → null/v8
+    Status   nullable.Type[model.ExampleStatus] // custom enum → nullable.Type
+    SortKey  nullable.Type[model.ExampleSortKey]
 }
 
-// Bad - Avoid pointers for optional filter fields
+// Bad - nullable.Type used for a primitive (use null.Bool / null.Int64)
 type ListExamplesQuery struct {
-    Status  *model.ExampleStatus   // Don't use pointers
-    SortKey *model.ExampleSortKey  // Don't use pointers
-    Role    *model.AdminRole       // Don't use pointers
+    IsActive nullable.Type[bool]  // WRONG → null.Bool
+    MinScore nullable.Type[int64] // WRONG → null.Int64
+}
+
+// Bad - bare pointers for optional filter fields
+type ListExamplesQuery struct {
+    Status *model.ExampleStatus // WRONG → nullable.Type[model.ExampleStatus]
 }
 ```
 
-**Why `nullable.Type[T]`:**
+In repository impls, read primitive `null/v8` fields via the typed accessor (`.Bool`, `.Int64`,
+`.Float64`), and custom `nullable.Type[T]` via `.Value()`:
 
-- Consistent with codebase conventions
-- Provides `.Valid` and `.Value()` methods for safer access
-- Works seamlessly with validation patterns in repository implementations
-- Avoids nil pointer dereference risks
+```go
+if query.IsActive.Valid {
+    mods = append(mods, dbmodel.ExampleWhere.IsActive.EQ(query.IsActive.Bool))
+}
+if query.Status.Valid && query.Status.Value().Valid() {
+    mods = append(mods, dbmodel.ExampleWhere.Status.EQ(query.Status.Value().String()))
+}
+```
+
+**Why split this way:**
+
+- `null/v8` is the canonical optional type for primitives/time across the codebase (DB models,
+  domain models, inputs all use it); `nullable.Type[T]` exists only to cover types `null/v8`
+  cannot represent (generics over custom types).
+- Both provide `.Valid` for safe access and avoid nil-pointer dereference.
 
 **When to use which:**
 | Type | Use Case |
 |------|----------|
 | `null.String` | Optional string fields (IDs, names) |
-| `null.Uint64` | Optional numeric fields (pagination) |
-| `nullable.Type[T]` | Optional enum/custom type fields (status, role, sort key) |
+| `null.Int64` | Optional integer fields |
+| `null.Float64` | Optional decimal/rate fields |
+| `null.Bool` | Optional boolean fields |
+| `null.Time` | Optional timestamp fields |
+| `null.Uint64` | Optional pagination fields |
+| `nullable.Type[T]` | Optional **custom-type** fields only: enums (status, role, sort key), domain structs, `civil.Date` |
 
 ### Base Options (defined in `base_options.go`)
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -63,6 +63,62 @@ func TestExampleInteractor_Create(t *testing.T) {
 }
 ```
 
+## Usecase interactor tests (MUST)
+
+Tests for `internal/usecase/*_impl.go` interactors are held to these hard requirements. The canonical
+references are `admin_tenant_impl_test.go` and `admin_staff_impl_test.go` — match their shape.
+
+1. **Table-driven only.** Every interactor method's test MUST be a single
+   `Test{Receiver}_{Method}` using `tests := map[string]testcaseFunc{...}` + a
+   `for name, tc := range tests { t.Run(name, ...) }` loop. Flat sequential tests (a `Test*` function
+   that calls the interactor directly with no `map[string]testcaseFunc`) are **prohibited** — every case,
+   including error cases, lives in the one table. (See ai-antipatterns **#3**.)
+2. **Test data from the factory only.** All fixtures MUST come from `factory.NewFactory()`. When you need
+   a new entity, or a **computed/derived value** (a `*Calculation`, box-faces set, etc.), **extend the
+   factory** — never inline `&model.X{...}` literals and never add a package-level
+   `func newThing(...)`/`func thingCalculation(...)` helper in the test file. (See ai-antipatterns
+   **#6** and **#42**.) Use `factory.CloneValue` for an independent copy.
+3. **No package-level funcs in test files.** Only `func Test*` is allowed at package level; any helper is
+   a closure inside the `Test*` function (per the helper rule below). (See ai-antipatterns **#31**.)
+4. **Case coverage.** Each method covers `invalid argument` (when the input has a validatable field),
+   `not found` (for Get/Update/Delete that fetch first), and `success`.
+5. **Parallel.** `t.Parallel()` at both the outer test and every inner `t.Run`. When a case needs a
+   deterministic ID, call `id.Mock()` inside that case's closure (matches the canonical references).
+6. **Exact mock matching.** Only `context` uses `gomock.Any()`; the `requestTime` argument of
+   `BatchSet*URLs` may also use `gomock.Any()` per the documented pattern. Everything else is matched
+   exactly. (See ai-antipatterns **#1**.)
+
+```go
+// BAD - flat sequential usecase test, inline literal fixture, package-level helper
+func awningCalculation(t time.Time) *model.AwningEstimateCalculation { return &model.AwningEstimateCalculation{...} }
+
+func TestAdminAwningEstimateInteractor_Calculate(t *testing.T) {
+    t.Parallel()
+    testdata := factory.NewFactory()
+    calc := awningCalculation(testdata.RequestTime) // ad-hoc helper + inline literal
+    // ... single case, no map[string]testcaseFunc
+}
+
+// GOOD - table-driven, factory fixture, all cases in one Test func
+func TestAdminAwningEstimateInteractor_Calculate(t *testing.T) {
+    t.Parallel()
+    type want struct { calculation *model.AwningEstimateCalculation; err error }
+    type testcase struct { param *input.AdminCalculateAwningEstimate; usecase AdminAwningEstimateInteractor; want want }
+    type testcaseFunc func(ctx context.Context, ctrl *gomock.Controller) testcase
+    tests := map[string]testcaseFunc{
+        "invalid argument": func(ctx context.Context, ctrl *gomock.Controller) testcase { /* ... */ },
+        "success": func(ctx context.Context, ctrl *gomock.Controller) testcase {
+            testdata := factory.NewFactory()
+            calc := testdata.AwningEstimateCalculation // factory fixture, not a helper
+            // ...
+        },
+    }
+    for name, tc := range tests {
+        t.Run(name, func(t *testing.T) { t.Parallel(); /* ... */ })
+    }
+}
+```
+
 ## Test Case Structure
 
 ```go

--- a/.claude/rules/usecase-interactor.md
+++ b/.claude/rules/usecase-interactor.md
@@ -686,6 +686,14 @@ examples, err := i.exampleRepository.List(ctx, repository.ListExamplesQuery{
 
 **Always** call `BatchSet{Entity}URLs`. Always call it even if the entity currently has no asset fields (such as profile images).
 
+**No exceptions for masters or singletons.** This applies to **every** resource-returning method —
+including master/lookup `List`s (e.g. `LeaseProduct`, `Fabric`) and singleton `Get`s (e.g.
+`LeasePricingSettings`) that have no asset field and no `ReadonlyReference` today. Each returned type
+still needs its own `BatchSet{Entity}URLs` (a defensive no-op loop) on `service.Asset`, the query
+still sets `Preload: true`, and the interactor still calls it. A singleton whose `Get` returns
+`*model.X` is wrapped in its slice type (e.g. `model.LeasePricingSettingsList{settings}`) so the call
+keeps the slice convention.
+
 ```go
 // Good - Call BatchSet even if no asset fields exist
 func (i *adminExampleInteractor) Get(
@@ -852,7 +860,13 @@ func (i *adminAdminInteractor) Delete(
 
 ## Optional Update Fields with nullable.Type
 
-For optional update fields, use `nullable.Type[T]` instead of pointers:
+For optional update fields, use `nullable.Type[T]` instead of pointers — but **only for custom
+types** (domain enums, `civil.Date`). Optional **primitive/time** input and `Update`-param fields
+use `null/v8` (`null.Int64`, `null.Bool`, `null.Float64`, `null.Time`, `null.String`), never
+`nullable.Type[int64/bool/float64/time.Time/string]`. In handlers, build these from optional proto
+fields with the matching `null/v8` constructor (`null.StringFromPtr`, `null.Int64FromPtr`,
+`null.BoolFromPtr`, `null.Float64FromPtr`) rather than ad-hoc `nullable` wrappers. See the type
+table in `repository.md`.
 
 ### Input Struct
 

--- a/.claude/skills/audit-rules/SKILL.md
+++ b/.claude/skills/audit-rules/SKILL.md
@@ -48,15 +48,20 @@ git ls-files 'db/**/migrations/**/*.sql' 'db/**/constants/**/*.yaml'
 Assign each file to exactly one partition using the table below. Files matching multiple
 patterns go to the **first** matching partition.
 
+Every non-test partition's `convention-reviewer` applies the **full** `.claude/rules/*.md` set, the
+matching `checklists.md` section, AND the **whole `ai-antipatterns.md` catalog** (#7–#50 are non-test
+conventions). The "Rule files" column below lists the *primary* rules for each partition; it is not an
+exhaustive allow-list — every rule and anti-pattern applies wherever its layer matches.
+
 | Partition | glob patterns | Reviewer | Rule files |
 |-----------|--------------|----------|------------|
-| `domain` | `internal/domain/**` (non-test) | convention-reviewer | domain-model.md, domain-errors.md, domain-service.md, repository.md |
-| `usecase` | `internal/usecase/**` (non-test) | convention-reviewer | usecase-interactor.md, domain-service.md |
-| `grpc` | `internal/infrastructure/grpc/internal/handler/**` (non-test) | convention-reviewer | grpc-handler.md |
-| `db-repo` | `internal/infrastructure/{mysql,postgresql,spanner}/**` (non-test), `internal/infrastructure/dependency/**` | convention-reviewer | repository.md, dependency-injection.md, external-service-integration.md |
+| `domain` | `internal/domain/**` (non-test) | convention-reviewer | domain-model.md, domain-errors.md, domain-service.md, repository.md, ai-antipatterns.md (non-test) |
+| `usecase` | `internal/usecase/**` (non-test) | convention-reviewer | usecase-interactor.md, domain-service.md, ai-antipatterns.md (non-test, incl. #50) |
+| `grpc` | `internal/infrastructure/grpc/internal/handler/**` (non-test) | convention-reviewer | grpc-handler.md, ai-antipatterns.md (non-test) |
+| `db-repo` | `internal/infrastructure/{mysql,postgresql,spanner}/**` (non-test), `internal/infrastructure/dependency/**` | convention-reviewer | repository.md, dependency-injection.md, external-service-integration.md, ai-antipatterns.md (non-test) |
 | `proto` | `schema/proto/**/*.proto` | convention-reviewer | proto-definition.md |
 | `migration` | `db/**/migrations/**/*.sql`, `db/**/constants/**/*.yaml` | convention-reviewer | migration.md |
-| `infra-other` | `internal/infrastructure/{cognito,firebase,gcs,s3,redis,http,aws,cmd}/**` (non-test), `cmd/**` (non-test) | convention-reviewer | external-service-integration.md, webhook-implementation.md, job-system.md, worker-pattern.md, cli-command-pattern.md |
+| `infra-other` | `internal/infrastructure/{cognito,firebase,gcs,s3,redis,http,aws,cmd}/**` (non-test), `cmd/**` (non-test) | convention-reviewer | external-service-integration.md, webhook-implementation.md, job-system.md, worker-pattern.md, cli-command-pattern.md, ai-antipatterns.md (non-test) |
 | `tests` | `**/*_test.go` | **test-reviewer** | testing.md, ai-antipatterns.md (#1-#6) |
 
 If a single partition has more than ~60 files, split it into sub-batches and run agents
@@ -173,12 +178,15 @@ Wait for all agents to complete before proceeding.
 Priority order (same as review-diff):
 
 1. **Correctness** (CL-* that break runtime behavior: missing ForUpdate, Preload, state transition via wrong method)
-2. **Convention** (CL-*: method ordering, naming, pattern compliance, null.v8/now.Now(), ReadonlyReference)
+2. **Convention** (CL-*: method ordering, naming, pattern compliance, null.v8/now.Now(), ReadonlyReference, and the **return pattern (#50)** — a resource returned without `Preload: true` + `BatchSet{Entity}URLs` is an auto-fixable convention finding, even for master/lookup lists and singleton gets; add the defensive no-op `BatchSet` to `service.Asset` if it is missing)
 3. **Anti-patterns** (AP-1–AP-6 in tests: gomock.Any() misuse, missing t.Parallel(), table-driven pattern)
-4. **Test quality** (TEST-*: missing coverage, weak assertions)
+4. **Test structure** (TEST-*/AP-3/AP-6/AP-42: converting a flat sequential test to table-driven `map[string]testcaseFunc`, and moving inline-literal / package-level-helper fixtures into `factory.NewFactory()`). This is **mechanical and IS auto-fixable** — do it, do not defer it.
+5. **Test quality** (TEST-*: weak assertions, and adding obvious `invalid argument`/`not found`/`success` cases modeled on an existing case)
 
 Do **not** auto-fix findings that require spec interpretation or cross-file architectural
-decisions — list these as manual actions in the report.
+decisions — list these as manual actions in the report. Note that "not table-driven" and
+"ad-hoc fixture instead of factory" are **NOT** in that deferred bucket: they are mechanical
+conversions (priority 4 above) and must be fixed, not deferred as "coverage gaps."
 
 ## Step 6: Verify Fixes (with Retry Loop)
 

--- a/.claude/skills/review-diff/SKILL.md
+++ b/.claude/skills/review-diff/SKILL.md
@@ -65,6 +65,8 @@ Read `references/ai-antipatterns.md`. Check **every changed file** against all p
 - **#46** Void mutator on a domain model (should return receiver `*Entity` or `(*Entity, error)`)
 - **#47** Usecase branching on raw domain model fields instead of calling a predicate
 - **#48** Precondition duplicated in usecase immediately before a model method that already checks it
+- **#49** `nullable.Type[T]` used for a primitive (int/bool/float64/time.Time/string) — use the matching `null/v8` type
+- **#50** Usecase returns a resource without `Preload: true` + a per-entity-type `BatchSet{Entity}URLs` call (and every returned type must have its own, possibly empty-but-recursing, setter)
 
 Record each finding: file path, line number, pattern violated, fix to apply.
 

--- a/.claude/skills/review-diff/references/ai-antipatterns.md
+++ b/.claude/skills/review-diff/references/ai-antipatterns.md
@@ -123,6 +123,8 @@ updatedStaff.DisplayName = "Updated Name"
 
 **Why**: The factory generates consistent, cross-referenced test data with faker. Direct initialization risks missing fields, inconsistent references (e.g., `Staff.TenantID` not matching `Tenant.ID`), and breaks when new required fields are added to the model.
 
+**Also applies to computed/derived fixtures**: service `Calculate` results (`*Calculation`), box-faces sets, and similar derived values belong in the factory too — add a field to `factory.NewFactory()` and reference `testdata.XxxCalculation`. Do not inline them as `&model.XxxCalculation{...}` literals or build them in a package-level test helper (see #42).
+
 **Exception**: Empty structs used solely as `CloneValue` targets (`&model.Staff{}`) are acceptable.
 
 ---
@@ -851,9 +853,9 @@ invoice := testdata.Invoice
 organizationID := invoice.OrganizationID
 ```
 
-**Why**: `factory.NewFactory()` provides deterministic go-faker fixtures with consistent related entity references. Ad-hoc helpers diverge from factory data, cause inconsistency between tests, and duplicate responsibilities.
+**Why**: `factory.NewFactory()` provides deterministic go-faker fixtures with consistent related entity references. Ad-hoc helpers diverge from factory data, cause inconsistency between tests, and duplicate responsibilities. This holds for **computed/derived fixtures** too (e.g. a `func awningCalculation(...) *model.AwningEstimateCalculation` helper) — they belong in the factory, not in a package-level test helper or an inline literal.
 
-**Fix**: Delete the helper function. Use `factory.NewFactory()` and access the entity via `testdata.Invoice` (or whichever entity field). If the factory doesn't have the entity yet, add it to `factory.go` following the existing pattern.
+**Fix**: Delete the helper function. Use `factory.NewFactory()` and access the entity via `testdata.Invoice` (or whichever entity field). If the factory doesn't have the entity (or computed value) yet, add it to `factory.go` following the existing pattern.
 
 ---
 
@@ -1090,3 +1092,95 @@ inv, err = inv.Finalize(pm, t)  // model's own guard remains the safety net
 ```
 
 **Fix**: Delete the usecase/service check. Let the model method's own guard produce the authoritative error. If a silent return is needed (webhook idempotency), keep the predicate call but document it as an idempotency guard, not a validation.
+
+### 49. `nullable.Type[T]` used for a primitive (int/int64/bool/float64/time.Time/string)
+
+`nullable.Type[T]` (`internal/pkg/nullable`) exists only for optional **custom** types that
+`null/v8` cannot represent — domain enums, domain structs, and `civil.Date`. Every primitive and
+time type has a matching `null/v8` type, so using `nullable.Type[...]` for one is always wrong. This
+applies everywhere an optional field appears: domain model fields, `Update` method params,
+repository query filters, and input DTOs.
+
+```go
+// BAD - nullable.Type wrapping a primitive
+type ListFabricsQuery struct {
+    IsActive nullable.Type[bool]   // → null.Bool
+}
+func (m *LeaseEstimate) Update(usageDays nullable.Type[int64], ...) { // → null.Int64
+    if usageDays.Valid { m.UsageDays = usageDays.Value() }
+}
+
+// GOOD - null/v8 for primitives; nullable.Type only for custom types
+type ListFabricsQuery struct {
+    IsActive null.Bool
+}
+func (m *LeaseEstimate) Update(usageDays null.Int64, setupType nullable.Type[LeaseSetupTeardownType], ...) {
+    if usageDays.Valid { m.UsageDays = usageDays.Int64 }   // typed accessor, not .Value()
+    if setupType.Valid { m.SetupTeardownType = setupType.Value() } // custom type → nullable.Type OK
+}
+```
+
+Mapping: `int`/`int64`→`null.Int64`, `bool`→`null.Bool`, `float64`→`null.Float64`,
+`time.Time`→`null.Time`, `string`→`null.String`, `uint64`→`null.Uint64`. Read primitive values via
+the typed accessor (`.Int64`/`.Bool`/`.Float64`), and `nullable.Type[T]` via `.Value()`.
+
+**Fix**: Replace the `nullable.Type[primitive]` with the matching `null/v8` type and switch
+`.Value()` reads to the typed accessor. In handlers, build from optional proto fields with
+`null.Int64FromPtr`/`null.BoolFromPtr`/`null.Float64FromPtr`/`null.StringFromPtr` instead of custom
+`nullable` wrapper helpers (antipattern #40).
+
+### 50. Usecase returns a resource without preload + a `BatchSet{Entity}URLs` call
+
+Every usecase method that returns a domain entity must (a) load it with `Preload: true` on the
+final `Get`/`List`, and (b) run the asset URL setter `BatchSet{Entity}URLs` for the **returned
+entity type** before returning — always, even when the entity has no asset field today (defensive
+programming, see usecase-interactor.md §"Return Pattern Best Practices" and domain-service.md
+§"Asset Service Pattern"). Correspondingly, every returned entity type must HAVE its own
+`BatchSet{Entity}URLs` method on `service.Asset` (an empty-but-recursing method when it has no
+asset field — like `BatchSetTenantURLs`). Calling the parent's `BatchSet` from a child interactor
+(e.g. `BatchSetEstimateURLs` from the lease-estimate interactor that returns `*model.LeaseEstimate`)
+violates the per-returned-type contract.
+
+**No master/singleton exception.** This holds for master/lookup `List`s (`LeaseProduct`, `Fabric`, …)
+and singleton `Get`s (`LeasePricingSettings`, `FabricPricingSettings`) too — assetless, relation-less
+entities still need `Preload: true`, a defensive no-op `BatchSet{Entity}URLs`, and the call. For a
+singleton whose `Get` returns `*model.X`, add a slice type (`model.LeasePricingSettingsList`) and wrap:
+`BatchSetLeasePricingSettingsURLs(ctx, model.LeasePricingSettingsList{settings}, t)`.
+
+```go
+// BAD - returns LeaseEstimate but calls the PARENT's setter (no BatchSetLeaseEstimateURLs exists)
+leaseEstimate, _ := i.leaseEstimateRepository.Get(ctx, repository.GetLeaseEstimateQuery{
+    BaseGetOptions: repository.BaseGetOptions{OrFail: true, Preload: true},
+    ID:             null.StringFrom(param.LeaseEstimateID),
+})
+_ = i.assetService.BatchSetEstimateURLs(ctx, model.Estimates{leaseEstimate.ReadonlyReference.Estimate}, t)
+return leaseEstimate, nil
+
+// GOOD - dedicated per-entity setter (recurses into the parent estimate internally)
+leaseEstimate, _ := i.leaseEstimateRepository.Get(ctx, repository.GetLeaseEstimateQuery{
+    BaseGetOptions: repository.BaseGetOptions{OrFail: true, Preload: true},
+    ID:             null.StringFrom(param.LeaseEstimateID),
+})
+_ = i.assetService.BatchSetLeaseEstimateURLs(ctx, model.LeaseEstimates{leaseEstimate}, t)
+return leaseEstimate, nil
+
+// GOOD - the empty-but-recursing setter on service.Asset
+func (s *assetService) BatchSetLeaseEstimateURLs(ctx context.Context, leaseEstimates model.LeaseEstimates, t time.Time) error {
+    for _, le := range leaseEstimates {
+        if le.ReadonlyReference != nil && le.ReadonlyReference.Estimate != nil {
+            if err := s.BatchSetEstimateURLs(ctx, model.Estimates{le.ReadonlyReference.Estimate}, t); err != nil {
+                return err
+            }
+        }
+    }
+    return nil
+}
+```
+
+**Why**: returning preloaded entities means future relation additions are surfaced automatically;
+the per-type `BatchSet` means future asset fields (and recursive relation URLs) are populated
+without touching call sites. Skipping either, or borrowing the parent's setter, silently drops
+URLs the moment an asset field is added.
+
+**Fix**: add `Preload: true` to the returned `Get`/`List`; add a `BatchSet{Entity}URLs` method for
+the returned type (empty-but-recursing if no asset field) and call it for every returned entity.

--- a/.claude/skills/review-diff/references/checklists.md
+++ b/.claude/skills/review-diff/references/checklists.md
@@ -14,7 +14,7 @@ Detailed checklists for each file category. Apply the relevant sections based on
 - [ ] Entity has `ReadonlyReference` struct pointer for relations
 - [ ] Constructor uses `id.New()` for ID generation
 - [ ] Constructor sets both `CreatedAt` and `UpdatedAt` to same time
-- [ ] Update methods use `null.String`, `null.Int64` for optional fields
+- [ ] Optional primitive/time fields & Update params use `null/v8` (`null.Int64`/`null.Bool`/`null.Float64`/`null.Time`/`null.String`), NOT `nullable.Type[primitive]` (#49); `nullable.Type[T]` only for custom types (enums, `civil.Date`)
 - [ ] Update methods always update `UpdatedAt`
 - [ ] Status/Enum types have `Unknown` as first constant
 - [ ] Status types have `String()` and `Valid()` methods
@@ -28,13 +28,14 @@ Detailed checklists for each file category. Apply the relevant sections based on
 
 - [ ] Does NOT inject `transactable` — transaction boundaries belong to the usecase layer
 - [ ] Does NOT call `RWTx` / `ROTx` directly — assumes transaction is already active in context
+- [ ] Asset service has a `BatchSet{Entity}URLs` for every entity a usecase returns — empty-but-recursing if the entity has no asset field, including master/lookup entities and singletons; a singleton uses a plural slice type (e.g. `LeasePricingSettingsList`) so the method keeps the slice signature (#50)
 - [ ] No package-level private functions (use receiver methods on service struct)
 
 ## Repository Interface (`internal/domain/repository/**`)
 
 - [ ] Has `//go:generate` directive for mockgen
-- [ ] Query structs use `null.String`, `null.Uint64` for optional string/numeric fields
-- [ ] Query structs use `nullable.Type[T]` for optional enum/custom type fields
+- [ ] Query structs use `null/v8` for optional primitives (`null.String`/`null.Int64`/`null.Bool`/`null.Float64`/`null.Uint64`/`null.Time`) — never `nullable.Type[primitive]` (#49)
+- [ ] Query structs use `nullable.Type[T]` ONLY for optional custom types (enums, sort keys, `civil.Date`)
 - [ ] `BaseGetOptions`, `BaseBatchGetOptions`, `BaseListOptions` properly embedded
 
 ## Repository Implementation (`internal/infrastructure/**/repository/**`)
@@ -69,8 +70,8 @@ Detailed checklists for each file category. Apply the relevant sections based on
 - [ ] No unnecessary intermediate variable declarations (return directly when possible)
 - [ ] IdP sync (StoreClaims/DeleteUser) happens within transaction
 - [ ] On delete: IdP deletion before database deletion
-- [ ] Final return fetches entity with `Preload: true` for fresh data
-- [ ] Asset service called even if no assets currently exist
+- [ ] Final return fetches entity with `Preload: true` for fresh data (#50)
+- [ ] `BatchSet{Entity}URLs` called for the RETURNED entity type, even if no assets currently exist — not the parent's setter (#50)
 - [ ] No package-level private functions (inline or move to struct method)
 
 ## Input Struct (`internal/usecase/input/**`)
@@ -78,7 +79,7 @@ Detailed checklists for each file category. Apply the relevant sections based on
 - [ ] Named as `{Actor}{Action}{Resource}`
 - [ ] Has `RequestTime` field with `validate:"required"`
 - [ ] Has `Validate()` method that uses `validation.Validate()`
-- [ ] Optional update fields use `nullable.Type[T]` (not pointers)
+- [ ] Optional update fields: `null/v8` for primitives/time (not pointers, not `nullable.Type[primitive]` #49); `nullable.Type[T]` only for custom types
 - [ ] Validation includes business rule checks for optional fields
 
 ## gRPC Handler (`internal/infrastructure/grpc/internal/handler/**`)
@@ -87,6 +88,7 @@ Detailed checklists for each file category. Apply the relevant sections based on
 - [ ] Gets request time via `request_interceptor.GetRequestTime(ctx)`
 - [ ] Converts proto to input struct correctly
 - [ ] Handles optional proto fields with `if req.Field != nil` pattern
+- [ ] Optional proto primitives → input via `null/v8` FromPtr (`null.StringFromPtr`/`null.Int64FromPtr`/`null.BoolFromPtr`/`null.Float64FromPtr`), not custom `nullable` wrapper helpers (#40, #49)
 - [ ] Returns error directly (interceptor handles conversion)
 - [ ] Uses marshaller for domain-to-proto conversion
 
@@ -122,12 +124,14 @@ Detailed checklists for each file category. Apply the relevant sections based on
 
 ## Tests (`**/*_test.go`)
 
-- [ ] Uses table-driven tests with `map[string]testcaseFunc`
+- [ ] Uses table-driven tests with `map[string]testcaseFunc` — usecase interactor tests are table-driven ONLY (no flat sequential `Test*`); every case incl. errors lives in the one `Test{Receiver}_{Method}` (#3)
+- [ ] Each interactor method covers `invalid argument` / `not found` (where applicable) / `success`
+- [ ] Computed/derived fixtures (`*Calculation`, box-faces, …) come from the factory, not inline literals or package-level helpers (#6, #42)
 - [ ] Test function returns `(args, usecase/service, want)` tuple
 - [ ] Mock setup uses closure pattern with `func(ctrl *gomock.Controller)`
 - [ ] Transactable mock uses `DoAndReturn` to execute function
 - [ ] Error assertions use `assert.ErrorIs(t, err, want.err)`
-- [ ] Test data created via `factory.NewFactory()`, not direct model struct initialization
+- [ ] Test data created via `factory.NewFactory()` + `testdata.X` (and `factory.CloneValue` for copies), NOT `&model.X{...}` literals or ad-hoc `newTestX()` helpers (#6, #42) — if the entity isn't in the factory yet, add it to `factory.go`
 
 ## Dependency Injection (`internal/infrastructure/dependency/**`)
 


### PR DESCRIPTION
## Proposed Changes

Contribute generalizable `.claude/` rule improvements developed in the sunabe-server derived project back into the rapid-go template. Project-specific infrastructure narrowing (sunabe is PostgreSQL/Firebase/GCS only) and pure token differences were intentionally **not** synced, so this PR preserves rapid-go's multi-DB (MySQL/Spanner/PostgreSQL) and multi-auth (Cognito/Firebase) content.

## Implementation

**Overwritten (DB-agnostic, additions only) — 9 files**
- `rules/domain-model.md` — Field Type Conventions + ReadonlyReference field-type guidance
- `rules/usecase-interactor.md` — master/singleton `BatchSet` exception + null/v8 update-field rule
- `rules/proto-definition.md` — "RPC & Message Ordering" + master/reference-RPC grouping
- `agents/convention-reviewer.md`, `agents/test-reviewer.md` — reviewer guidance
- `skills/audit-rules/SKILL.md` — full ai-antipatterns catalog per partition + priorities
- `skills/review-diff/SKILL.md` + `references/ai-antipatterns.md` — anti-patterns #49, #50
- `skills/review-diff/references/checklists.md` — null/v8 split + BatchSet/#49/#50 items

**Selectively grafted (generalizable parts only; multi-DB content preserved) — 3 files**
- `rules/migration.md` — added `### History / Audit Tables Read as History` (multi-DB structure untouched)
- `rules/repository.md` — replaced `### Optional Fields` with null/v8-for-primitives vs nullable.Type-for-custom (MySQL/PostgreSQL/Spanner impl sections untouched)
- `rules/testing.md` — added `## Usecase interactor tests (MUST)` (multi-DB repo-test location untouched)

Generated via `/sync-claude-config` (rapid-go = upstream template; sunabe-server = derived project). No content flowed the other direction — nothing upstream was newer.