### PR TITLE
chore(claude): scope rules with paths frontmatter and bound reviewer context

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -109,8 +109,7 @@ Detailed coding rules are organized by theme in `.claude/rules/`:
 | `webhook-implementation.md` | `webhook/**`, `internal/infrastructure/http/internal/handler/webhook_*` | Webhook endpoint patterns (HTTP → gRPC routing) |
 | `job-system.md` | `job/**`, `cmd/app/internal/task_cmd/process_job_cmd/` | Async job queue patterns (SNS/SQS → AWS Batch) |
 | `worker-pattern.md` | `worker/**`, `cmd/app/internal/worker_cmd/` | Background worker patterns (SQS/Pub/Sub subscribers) |
-| `cli-command-pattern.md` | `cmd/app/internal/task_cmd/**`, `internal/usecase/task_*` | CLI command implementation patterns (`./app task` commands) |
-| `device-group-authorization.md` | `session_interceptor/**`, `handler/**`, `device_group_*` | Device group 3-layer authorization patterns |
+| `cli-command-pattern.md` | `internal/infrastructure/cmd/internal/task_cmd/**`, `internal/usecase/task_*` | CLI command implementation patterns (`./app task` commands) |
 | `package-placement.md` | `internal/pkg/**`, `internal/domain/**` | Where to put new packages — pkg is domain-agnostic only |
 | `object-storage-paths.md` | `internal/domain/model/asset.go`, `s3/**`, `gcs/**`, `job_*` | S3/GCS path prefix 集約と private/ prefix 規約 |
 

--- a/.claude/agents/bug-reviewer.md
+++ b/.claude/agents/bug-reviewer.md
@@ -118,3 +118,15 @@ For each finding, assign a `semantic_category` used by the orchestrator for dedu
 ### Summary
 Non-test files scanned: N, Anti-patterns found: N, Bugs found: N, Total findings: N (error: N, warning: N, info: N)
 ```
+
+# Context Budget (must follow)
+
+コンテキスト上限での失敗 (autocompact スラッシング / "Prompt is too long") を防ぐため:
+
+- レビュー対象の diff にフォーカスする。関係のないディレクトリ・ファイルをリポジトリ全体から無差別に探索しない
+- `git diff <base>...HEAD` を一括実行しない。プロンプトで渡されたファイルごとに `git diff <base>...HEAD -- <path>` で個別に diff を取る
+- 生成物 (`internal/**/mock/**`, `internal/infrastructure/grpc/pb/**`, `internal/infrastructure/{mysql,postgresql,spanner}/internal/dbmodel/**`) と削除済みファイルの diff / Read はしない
+- 大きいファイルは全文 Read せず、400 行以下のチャンクで range 指定するか grep で該当箇所を絞り込んでから読む
+- `.claude/rules/*.md` は自分のレビュー対象レイヤーに該当するものだけ読む。全ファイルをまとめて読み込まない
+- 大きい tool 出力 (diff 全文・ファイル全文・コマンド出力) をそのまま応答に echo しない。中間確認は要点のみに留める
+- 最終出力は Output Format 通りの Findings/Summary のみとする。ファイル全文やコマンド出力の貼り付けは行わず、結論を簡潔にまとめる

--- a/.claude/agents/convention-reviewer.md
+++ b/.claude/agents/convention-reviewer.md
@@ -201,3 +201,15 @@ For each finding, assign a `semantic_category` used by the orchestrator for dedu
 ### Summary
 Files reviewed: N, Categories: N, Findings: N (error: N, warning: N, info: N)
 ```
+
+# Context Budget (must follow)
+
+コンテキスト上限での失敗 (autocompact スラッシング / "Prompt is too long") を防ぐため:
+
+- レビュー対象の diff にフォーカスする。関係のないディレクトリ・ファイルをリポジトリ全体から無差別に探索しない
+- `git diff <base>...HEAD` を一括実行しない。プロンプトで渡されたファイルごとに `git diff <base>...HEAD -- <path>` で個別に diff を取る
+- 生成物 (`internal/**/mock/**`, `internal/infrastructure/grpc/pb/**`, `internal/infrastructure/{mysql,postgresql,spanner}/internal/dbmodel/**`) と削除済みファイルの diff / Read はしない
+- 大きいファイルは全文 Read せず、400 行以下のチャンクで range 指定するか grep で該当箇所を絞り込んでから読む
+- `.claude/rules/*.md` は「全件 Read」の指示があっても、変更ファイルのカテゴリに該当するものを優先して読む。無関係なカテゴリのルールまで律儀に全文読み込まない
+- 大きい tool 出力 (diff 全文・ファイル全文・コマンド出力) をそのまま応答に echo しない。中間確認は要点のみに留める
+- 最終出力は Output Format 通りの Findings/Summary のみとする。ファイル全文やコマンド出力の貼り付けは行わず、結論を簡潔にまとめる

--- a/.claude/agents/security-perf-reviewer.md
+++ b/.claude/agents/security-perf-reviewer.md
@@ -144,3 +144,15 @@ For each finding, assign a `semantic_category` used by the orchestrator for dedu
 ### Summary
 Files reviewed: N, Security findings: N, Performance findings: N, TX findings: N, Total: N (error: N, warning: N, info: N)
 ```
+
+# Context Budget (must follow)
+
+コンテキスト上限での失敗 (autocompact スラッシング / "Prompt is too long") を防ぐため:
+
+- レビュー対象の diff にフォーカスする（AUDIT MODE の場合はプロンプトで渡されたファイル一覧のみ）。関係のないディレクトリ・ファイルをリポジトリ全体から無差別に探索しない
+- `git diff <base>...HEAD` を一括実行しない。プロンプトで渡されたファイルごとに `git diff <base>...HEAD -- <path>` で個別に diff を取る（AUDIT MODE では実行しない）
+- 生成物 (`internal/**/mock/**`, `internal/infrastructure/grpc/pb/**`, `internal/infrastructure/{mysql,postgresql,spanner}/internal/dbmodel/**`) と削除済みファイルの diff / Read はしない
+- 大きいファイルは全文 Read せず、400 行以下のチャンクで range 指定するか grep で該当箇所を絞り込んでから読む
+- `.claude/rules/*.md` は自分のレビュー対象レイヤーに該当するものだけ読む
+- 大きい tool 出力 (diff 全文・ファイル全文・コマンド出力) をそのまま応答に echo しない。中間確認は要点のみに留める
+- 最終出力は Output Format 通りの Findings/Summary のみとする。ファイル全文やコマンド出力の貼り付けは行わず、結論を簡潔にまとめる

--- a/.claude/agents/spec-reviewer.md
+++ b/.claude/agents/spec-reviewer.md
@@ -89,3 +89,15 @@ Spec sources: N, Findings: N (error: N, warning: N, info: N)
 - Report ambiguous spec areas as `info` level with "confirmation recommended"
 - Do not force findings when spec information is insufficient
 - Do not auto-fix — spec interpretation requires human judgment
+
+# Context Budget (must follow)
+
+コンテキスト上限での失敗 (autocompact スラッシング / "Prompt is too long") を防ぐため:
+
+- レビュー対象の diff とその spec ソース (PR/Issue/design doc) にフォーカスする。関係のないディレクトリ・ファイルをリポジトリ全体から無差別に探索しない
+- `git diff <base>...HEAD` を一括実行しない。プロンプトで渡されたファイルごとに `git diff <base>...HEAD -- <path>` で個別に diff を取る
+- 生成物 (`internal/**/mock/**`, `internal/infrastructure/grpc/pb/**`, `internal/infrastructure/{mysql,postgresql,spanner}/internal/dbmodel/**`) と削除済みファイルの diff / Read はしない
+- 大きいファイルは全文 Read せず、400 行以下のチャンクで range 指定するか grep で該当箇所を絞り込んでから読む
+- `.claude/rules/*.md` は自分のレビュー対象レイヤーに該当するものだけ読む
+- 大きい tool 出力 (diff 全文・ファイル全文・Issue/PR 本文全文など) をそのまま応答に echo しない。中間確認は要点のみに留める
+- 最終出力は Output Format 通りの Findings/Summary のみとする。ファイル全文やコマンド出力の貼り付けは行わず、結論を簡潔にまとめる

--- a/.claude/agents/test-reviewer.md
+++ b/.claude/agents/test-reviewer.md
@@ -160,3 +160,15 @@ for the missing `invalid argument` / `not found` / `success` case.
 ### Summary
 Test files: N, Total EXPECT(): N, gomock.Any() misuse: N, Total findings: N (error: N, warning: N, info: N)
 ```
+
+# Context Budget (must follow)
+
+コンテキスト上限での失敗 (autocompact スラッシング / "Prompt is too long") を防ぐため:
+
+- レビュー対象の diff (AUDIT MODE ではプロンプトで渡されたファイル一覧) にフォーカスする。関係のないディレクトリ・ファイルをリポジトリ全体から無差別に探索しない
+- `git diff <base>...HEAD` を一括実行しない。プロンプトで渡されたファイルごとに `git diff <base>...HEAD -- <path>` で個別に diff を取る（AUDIT MODE では実行しない）
+- 生成物 (`internal/**/mock/**`, `internal/infrastructure/grpc/pb/**`, `internal/infrastructure/{mysql,postgresql,spanner}/internal/dbmodel/**`) と削除済みファイルの diff / Read はしない
+- 大きいファイルは全文 Read せず、400 行以下のチャンクで range 指定するか grep で該当箇所を絞り込んでから読む
+- `.claude/rules/*.md` は自分のレビュー対象レイヤーに該当するものだけ読む
+- 大きい tool 出力 (diff 全文・ファイル全文・コマンド出力) をそのまま応答に echo しない。中間確認は要点のみに留める
+- 最終出力は Output Format 通りの Findings/Summary のみとする。ファイル全文やコマンド出力の貼り付けは行わず、結論を簡潔にまとめる

--- a/.claude/rules/cli-command-pattern.md
+++ b/.claude/rules/cli-command-pattern.md
@@ -1,3 +1,10 @@
+---
+description: CLI command implementation patterns (./app task commands)
+paths:
+  - "internal/infrastructure/cmd/internal/task_cmd/**"
+  - "internal/usecase/task_*"
+---
+
 # CLI Command Pattern Guidelines
 
 ## Overview

--- a/.claude/rules/dependency-injection.md
+++ b/.claude/rules/dependency-injection.md
@@ -1,6 +1,6 @@
 ---
 description: Dependency injection configuration patterns
-globs:
+paths:
   - "internal/infrastructure/dependency/**/*.go"
 ---
 

--- a/.claude/rules/domain-errors.md
+++ b/.claude/rules/domain-errors.md
@@ -1,6 +1,6 @@
 ---
 description: Domain error definition and handling patterns
-globs:
+paths:
   - "internal/domain/errors/**/*.go"
 ---
 

--- a/.claude/rules/domain-model.md
+++ b/.claude/rules/domain-model.md
@@ -1,6 +1,6 @@
 ---
 description: Domain model and entity conventions for the domain layer
-globs:
+paths:
   - "internal/domain/model/**/*.go"
 ---
 

--- a/.claude/rules/domain-service.md
+++ b/.claude/rules/domain-service.md
@@ -1,6 +1,6 @@
 ---
 description: Domain service patterns for complex business logic
-globs:
+paths:
   - "internal/domain/service/**/*.go"
 ---
 

--- a/.claude/rules/external-service-integration.md
+++ b/.claude/rules/external-service-integration.md
@@ -1,6 +1,6 @@
 ---
 description: External service integration patterns (Cognito, Firebase, S3, etc.)
-globs:
+paths:
   - "internal/domain/repository/*authentication*.go"
   - "internal/infrastructure/cognito/**/*.go"
   - "internal/infrastructure/firebase/**/*.go"

--- a/.claude/rules/grpc-handler.md
+++ b/.claude/rules/grpc-handler.md
@@ -1,6 +1,6 @@
 ---
 description: gRPC handler implementation patterns
-globs:
+paths:
   - "internal/infrastructure/grpc/**/*.go"
 ---
 

--- a/.claude/rules/invitation-workflow.md
+++ b/.claude/rules/invitation-workflow.md
@@ -1,6 +1,6 @@
 ---
 description: Invitation and approval workflow patterns for user onboarding
-globs:
+paths:
   - "internal/domain/model/*invitation*.go"
   - "internal/usecase/*invitation*.go"
 ---

--- a/.claude/rules/job-system.md
+++ b/.claude/rules/job-system.md
@@ -1,3 +1,9 @@
+---
+description: Async job queue patterns (SNS/SQS -> AWS Batch)
+paths:
+  - "**/*job*"
+---
+
 # Job System Guidelines
 
 ## Overview

--- a/.claude/rules/migration.md
+++ b/.claude/rules/migration.md
@@ -1,6 +1,6 @@
 ---
 description: Database migration file conventions and patterns
-globs:
+paths:
   - "db/mysql/migrations/**/*.sql"
   - "db/mysql/constants/**/*.yaml"
   - "db/postgresql/migrations/**/*.sql"

--- a/.claude/rules/object-storage-paths.md
+++ b/.claude/rules/object-storage-paths.md
@@ -1,7 +1,7 @@
 ---
 name: object-storage-paths
 description: S3/GCS object path prefix の AssetType 集約と private/ prefix 規約
-globs:
+paths:
   - internal/domain/model/asset.go
   - internal/domain/model/job_*.go
   - internal/infrastructure/s3/**/*.go

--- a/.claude/rules/package-placement.md
+++ b/.claude/rules/package-placement.md
@@ -1,6 +1,6 @@
 ---
 description: Where to put new Go packages — internal/pkg/ vs internal/domain/
-globs:
+paths:
   - "internal/pkg/**/*.go"
   - "internal/domain/**/*.go"
 ---

--- a/.claude/rules/proto-definition.md
+++ b/.claude/rules/proto-definition.md
@@ -1,6 +1,6 @@
 ---
 description: Protocol Buffers definition conventions (rapid-go)
-globs:
+paths:
   - "schema/proto/**/*.proto"
 ---
 

--- a/.claude/rules/repository.md
+++ b/.claude/rules/repository.md
@@ -1,6 +1,6 @@
 ---
 description: Repository interface, implementation, and marshaller patterns
-globs:
+paths:
   - "internal/domain/repository/**/*.go"
   - "internal/infrastructure/mysql/repository/**/*.go"
   - "internal/infrastructure/mysql/internal/marshaller/**/*.go"

--- a/.claude/rules/specification.md
+++ b/.claude/rules/specification.md
@@ -1,3 +1,9 @@
+---
+description: Specification document guidelines (docs/specifications/)
+paths:
+  - "docs/specifications/**"
+---
+
 # Specification Document Guidelines
 
 ## Overview

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,6 +1,6 @@
 ---
 description: Testing conventions and patterns
-globs:
+paths:
   - "**/*_test.go"
 ---
 

--- a/.claude/rules/usecase-interactor.md
+++ b/.claude/rules/usecase-interactor.md
@@ -1,6 +1,6 @@
 ---
 description: Usecase layer interactor implementation patterns
-globs:
+paths:
   - "internal/usecase/**/*.go"
 ---
 

--- a/.claude/rules/webhook-implementation.md
+++ b/.claude/rules/webhook-implementation.md
@@ -1,3 +1,9 @@
+---
+description: Webhook endpoint patterns (HTTP -> gRPC routing)
+paths:
+  - "**/*webhook*"
+---
+
 # Webhook Implementation Guidelines
 
 ## Overview

--- a/.claude/rules/worker-pattern.md
+++ b/.claude/rules/worker-pattern.md
@@ -1,3 +1,9 @@
+---
+description: Background worker patterns (SQS/Pub-Sub subscribers)
+paths:
+  - "**/*worker*"
+---
+
 # Worker Pattern Guidelines
 
 ## Overview


### PR DESCRIPTION
## Background

This repo's `.claude/` config predates the fix applied in the derived repo (PR #483 there): rule files used Cursor-style `globs:` frontmatter, which Claude Code does not use for scoping. The same fix is ported here, adapted to rapid-go's current rule set (this repo is the template side the derived repo syncs against).

## Problem

- Cursor-style `globs:` frontmatter is not recognized by Claude Code as a scope, so **every rule in `.claude/rules/` was loaded unconditionally into context** in every session.
- The same rules were also injected into the review subagents, contributing to context overflow / "Prompt is too long" failures during reviews.

## Changes

- **globs → paths**: converted `globs:` frontmatter to Claude Code's `paths:` in all rule files (values unchanged, key rename only; removed Cursor-only leftovers where present).
- **Missing frontmatter**: added `paths:` frontmatter to the 5 rules that had none — `cli-command-pattern`, `job-system`, `specification`, `webhook-implementation`, `worker-pattern` — derived from CLAUDE.md's Applies To table and verified against the actual repo layout.
- **Review agents**: added a Context Budget section to the 5 review subagents (`bug-reviewer`, `convention-reviewer`, `security-perf-reviewer`, `spec-reviewer`, `test-reviewer`): focus on the review-target diff, read large files in ranges, reference only diff-relevant rules, avoid echoing large tool output, return concise findings only. `config-sync-classifier` is intentionally untouched (read-only, compact-output by design).
- **CLAUDE.md cleanup**: removed the rules-table row referencing `device-group-authorization.md` (the rule file does not exist in this repo) and fixed the stale `cli-command-pattern` Applies To path (`cmd/app/internal/task_cmd/**` → `internal/infrastructure/cmd/internal/task_cmd/**`, matching the real layout).

## Repository-specific differences vs the derived repo's PR

- `organization-group-authorization.md` does not exist here — no equivalent change.
- `device-group-authorization.md` was referenced in CLAUDE.md but has no rule file here — resolved by removing the stale reference instead of porting a rule.

## Verification

- `grep -r 'globs:' .claude/` → 0 matches
- All 19 files in `.claude/rules/` have valid `paths:` frontmatter (19/19); none are frontmatter-less
- `Context Budget` present in exactly the 5 target agents; `config-sync-classifier.md` has no diff
- Final review pass (diff-only) found no Critical/Major issues; the two Minor findings (dead `internal/infrastructure/sqs/**` pattern in worker-pattern.md, stale CLAUDE.md path for cli-command-pattern) were fixed in this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)