### PR TITLE
chore(claude): disable CLAUDE_CODE_THRIFTY_SONIC so path-scoped rules are applied

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -149,6 +149,12 @@ Available automation skills in `.claude/skills/`:
 | `transaction has already been committed` | Transaction misuse | Ensure single `RWTx`/`ROTx` per operation flow |
 | `make` command not found or not working | Shell function override in Claude Code | Use full path `/usr/bin/make` instead of `make` |
 
+## Claude Code Settings (`.claude/settings.json`)
+
+- `.claude/settings.json` はリポジトリ全体で共有する Claude Code の設定。全員に同じ挙動を強制したいものだけをここに置き、個人の設定は `.claude/settings.local.json`(gitignore 済み)に置く。
+- `CLAUDE_CODE_THRIFTY_SONIC` を `"false"` に固定している。この feature flag が有効だと、auto mode のシステムプロンプトが「Read / Edit / Write ツールではなく Bash(cat / sed / grep)を使え」と指示する。Rules(`.claude/rules/` の `paths:` 付きルール)、Read ツールで発火する Hooks、サブディレクトリの CLAUDE.md はいずれも Read ツールの実行をトリガーに読み込まれるため、Bash で読まれると全てバイパスされてしまう。このリポジトリの Rules はほぼ全て `paths:` 付きなので、これを防ぐために無効化している。詳細: https://kawasin73.hatenablog.com/entry/2026/09/05/092056
+- この flag を削除・変更する前に、`.claude/rules/` のルールがファイル編集時に適用されることを確認すること。
+
 ## Implementation Preflight
 
 新規ファイル作成・大きな変更の前に必ず実施:

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "CLAUDE_CODE_THRIFTY_SONIC": "false"
+  }
+}


### PR DESCRIPTION
## 背景

https://kawasin73.hatenablog.com/entry/2026/09/05/092056 で指摘されている問題への対応です。

2026-08-18 以降、Claude Code の auto mode のシステムプロンプトに「Read / Edit / Write ツールではなく Bash(cat / sed / grep)を使え」という指示が入っています(feature flag `CLAUDE_CODE_THRIFTY_SONIC`)。以下はいずれも **Read ツールの実行をトリガーに読み込まれる** ため、Bash で読まれると全てバイパスされます。

- `.claude/rules/` の `paths:` 付き Rules
- Read ツールで発火する Hooks
- サブディレクトリの CLAUDE.md

このリポジトリの `.claude/rules/` はほぼ全て `paths:` 付き(`domain-model.md`, `repository.md`, `grpc-handler.md`, `testing.md` など)なので、auto mode で Bash 経由の読み書きになるとレイヤー別のコーディングルールが一切適用されない状態になります。

## Proposed Changes

- `.claude/settings.json` を新規追加し、`env.CLAUDE_CODE_THRIFTY_SONIC = "false"` を設定(リポジトリ共有設定なので、clone した全員に自動で適用される)
- `.claude/CLAUDE.md` に設定の意図と、変更前に確認すべきことを追記

## Implementation

Claude Code 2.1.263 で、`claude -p --model fable --permission-mode auto` に「システムプロンプトに `Do your work through the Bash tool` で始まる文があるか」を質問して確認:

| 条件 | 結果 |
|------|------|
| 設定なしのディレクトリ + 環境変数 `CLAUDE_CODE_THRIFTY_SONIC=true` | **YES** |
| 本リポジトリ(`.claude/settings.json` あり)+ 環境変数なし | **NO** |
| 本リポジトリ(`.claude/settings.json` あり)+ 環境変数 `true` | **NO** |

`.claude/settings.json` の `env` はプロセス環境変数より優先されるため、個人の環境に関わらずリポジトリ設定で無効化が固定されます。

## 補足

- 他のリポジトリにも同じ問題があるため、個人単位で対応するなら `~/.claude/settings.json` に同じ `env` を入れる方法もあります。